### PR TITLE
refactor: SDK architecture overhaul, fix memory leaks, sync reliability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
     id("com.android.library") version "8.9.1" apply false
     id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.1.0" apply false
 }

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.serialization")
     id("kotlin-parcelize")
     id("maven-publish")
 }
@@ -60,15 +61,16 @@ dependencies {
     // Security for EncryptedSharedPreferences
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
 
-    // Gson for JSON serialization
-    implementation("com.google.code.gson:gson:2.10.1")
+    // Kotlin Serialization for JSON
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
 
     // OkHttp for network requests
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
 
     // Testing
     testImplementation("org.jetbrains.kotlin:kotlin-test")
-    testImplementation("org.mockito:mockito-core:5.0.0")
+    testImplementation("io.mockk:mockk:1.13.13")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
 }
 
 afterEvaluate {
@@ -78,7 +80,7 @@ afterEvaluate {
                 from(components["release"])
                 groupId = "com.openwearables.health"
                 artifactId = "sdk"
-                version = "0.2.0"
+                version = "0.4.0"
 
                 pom {
                     name.set("Open Wearables Health SDK")

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -8,7 +8,15 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
-    <!-- Health Connect permissions -->
+    <!--
+        Health Connect permissions.
+
+        NOTE: READ_HEALTH_DATA_IN_BACKGROUND is a restricted permission.
+        Apps using this SDK must submit a declaration form in the Google Play
+        Console explaining why background health data access is necessary.
+        If denied, the SDK will still work but only read data while the app
+        is in the foreground. Handle the permission-denied case gracefully.
+    -->
     <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND" />
     <uses-permission android:name="android.permission.health.READ_STEPS" />
     <uses-permission android:name="android.permission.health.READ_HEART_RATE" />
@@ -32,9 +40,10 @@
     <uses-permission android:name="android.permission.health.READ_EXERCISE" />
     <uses-permission android:name="android.permission.health.READ_SLEEP" />
 
-    <!-- Package visibility: allow detecting Health Connect on Android 11+ -->
+    <!-- Package visibility: allow detecting Health Connect and Samsung Health on Android 11+ -->
     <queries>
         <package android:name="com.google.android.apps.healthdata" />
+        <package android:name="com.samsung.android.app.shealth" />
     </queries>
 
     <application>

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/Constants.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/Constants.kt
@@ -1,0 +1,34 @@
+package com.openwearables.health.sdk
+
+object ProviderIds {
+    const val SAMSUNG = "samsung"
+    const val GOOGLE = "google"
+}
+
+object ProviderDisplayNames {
+    const val SAMSUNG_HEALTH = "Samsung Health"
+    const val HEALTH_CONNECT = "Health Connect"
+}
+
+object SyncDefaults {
+    const val SYNC_INTERVAL_MINUTES = 15L
+    const val MIN_SYNC_INTERVAL_MINUTES = 15L
+    const val CHUNK_SIZE = 2000
+    const val WORK_NAME_PERIODIC = "health_sync_periodic"
+    const val WORK_NAME_EXPEDITED = "health_sync_expedited"
+    const val SDK_VERSION = "0.4.0"
+}
+
+object StorageKeys {
+    const val SYNC_PREFS_NAME = "com.openwearables.healthsdk.sync"
+    const val KEY_ANCHORS = "anchors"
+    const val SYNC_STATE_DIR = "health_sync_state"
+    const val SYNC_STATE_FILE = "state.json"
+}
+
+object NotificationConfig {
+    const val NOTIFICATION_ID = 9001
+    const val CHANNEL_ID = "health_sync_channel"
+    const val CHANNEL_NAME = "Health Sync"
+    const val CHANNEL_DESCRIPTION = "Background health data synchronization"
+}

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/DispatcherProvider.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/DispatcherProvider.kt
@@ -1,0 +1,20 @@
+package com.openwearables.health.sdk
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * Abstraction over coroutine dispatchers to enable unit testing with TestDispatcher
+ * and decouple the SDK from hardcoded Android dispatchers.
+ */
+interface DispatcherProvider {
+    val main: CoroutineDispatcher
+    val io: CoroutineDispatcher
+    val default: CoroutineDispatcher
+}
+
+internal class DefaultDispatcherProvider : DispatcherProvider {
+    override val main: CoroutineDispatcher = Dispatchers.Main
+    override val io: CoroutineDispatcher = Dispatchers.IO
+    override val default: CoroutineDispatcher = Dispatchers.Default
+}

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/HealthConnectManager.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/HealthConnectManager.kt
@@ -12,8 +12,8 @@ import androidx.health.connect.client.records.metadata.Metadata
 import androidx.health.connect.client.request.ReadRecordsRequest
 import androidx.health.connect.client.time.TimeRangeFilter
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.lang.ref.WeakReference
 import java.time.Instant
 import java.time.ZoneOffset
 import java.util.*
@@ -21,30 +21,40 @@ import kotlin.reflect.KClass
 
 class HealthConnectManager(
     private val context: Context,
-    private var activity: Activity?,
+    activity: Activity?,
+    private val dispatchers: DispatcherProvider,
     private val logger: (String) -> Unit
 ) : HealthDataProvider {
 
-    override val providerId = "google"
-    override val providerName = "Health Connect"
+    override val providerId = ProviderIds.GOOGLE
+    override val providerName = ProviderDisplayNames.HEALTH_CONNECT
 
     private var client: HealthConnectClient? = null
     private var trackedTypeIds: Set<String> = emptySet()
     private var permissionLauncher: ActivityResultLauncher<Set<String>>? = null
     private var pendingPermissionResult: CompletableDeferred<Set<String>>? = null
     private var launcherRegistered = false
+    private var activityRef: WeakReference<Activity>? = activity?.let { WeakReference(it) }
 
     // -----------------------------------------------------------------------
     // HealthDataProvider interface
     // -----------------------------------------------------------------------
 
+    /**
+     * Provide the current Activity. The permission launcher is registered here.
+     *
+     * IMPORTANT: For best reliability, call this during or before Activity.onCreate().
+     * Android's ActivityResultRegistry strongly recommends registering launchers
+     * unconditionally during the creation flow. Registering after onStart can cause
+     * crashes or state loss if the process is killed while a permission dialog is open.
+     */
     override fun setActivity(activity: Activity?) {
-        this.activity = activity
+        this.activityRef = activity?.let { WeakReference(it) }
         registerPermissionLauncher()
     }
 
     private fun registerPermissionLauncher() {
-        val act = activity as? ComponentActivity
+        val act = activityRef?.get() as? ComponentActivity
         if (act == null || launcherRegistered) return
 
         try {
@@ -80,6 +90,7 @@ class HealthConnectManager(
         return try {
             HealthConnectClient.getSdkStatus(context) == HealthConnectClient.SDK_AVAILABLE
         } catch (e: Exception) {
+            logger("Health Connect availability check failed: ${e.javaClass.simpleName}: ${e.message}")
             false
         }
     }
@@ -155,88 +166,75 @@ class HealthConnectManager(
         }
     }
 
+    // -----------------------------------------------------------------------
+    // Unified read methods (deduplicated)
+    // -----------------------------------------------------------------------
+
     override suspend fun readData(
         typeId: String,
         sinceTimestamp: Long?,
         limit: Int
-    ): ProviderReadResult = withContext(Dispatchers.IO) {
-        if (client == null) withContext(Dispatchers.Main) { connect() }
-        val hcClient = client ?: return@withContext ProviderReadResult(UnifiedHealthData(), null)
-
-        try {
-            when (typeId) {
-                "steps" -> readRecordType<StepsRecord>(hcClient, typeId, sinceTimestamp, limit) { convertSteps(it) }
-                "heartRate" -> readRecordType<HeartRateRecord>(hcClient, typeId, sinceTimestamp, limit) { convertHeartRate(it) }
-                "restingHeartRate" -> readRecordType<RestingHeartRateRecord>(hcClient, typeId, sinceTimestamp, limit) { convertRestingHeartRate(it) }
-                "heartRateVariabilitySDNN" -> readRecordType<HeartRateVariabilityRmssdRecord>(hcClient, typeId, sinceTimestamp, limit) { convertHrv(it) }
-                "oxygenSaturation" -> readRecordType<OxygenSaturationRecord>(hcClient, typeId, sinceTimestamp, limit) { convertOxygenSaturation(it) }
-                "bloodPressure", "bloodPressureSystolic", "bloodPressureDiastolic" -> readRecordType<BloodPressureRecord>(hcClient, typeId, sinceTimestamp, limit) { convertBloodPressure(it) }
-                "bloodGlucose" -> readRecordType<BloodGlucoseRecord>(hcClient, typeId, sinceTimestamp, limit) { convertBloodGlucose(it) }
-                "activeEnergy" -> readRecordType<ActiveCaloriesBurnedRecord>(hcClient, typeId, sinceTimestamp, limit) { convertActiveCalories(it) }
-                "basalEnergy" -> readRecordType<BasalMetabolicRateRecord>(hcClient, typeId, sinceTimestamp, limit) { convertBasalCalories(it) }
-                "bodyTemperature" -> readRecordType<BodyTemperatureRecord>(hcClient, typeId, sinceTimestamp, limit) { convertBodyTemperature(it) }
-                "bodyMass" -> readRecordType<WeightRecord>(hcClient, typeId, sinceTimestamp, limit) { convertWeight(it) }
-                "height" -> readRecordType<HeightRecord>(hcClient, typeId, sinceTimestamp, limit) { convertHeight(it) }
-                "bodyFatPercentage" -> readRecordType<BodyFatRecord>(hcClient, typeId, sinceTimestamp, limit) { convertBodyFat(it) }
-                "leanBodyMass" -> readRecordType<LeanBodyMassRecord>(hcClient, typeId, sinceTimestamp, limit) { convertLeanBodyMass(it) }
-                "flightsClimbed" -> readRecordType<FloorsClimbedRecord>(hcClient, typeId, sinceTimestamp, limit) { convertFloors(it) }
-                "distanceWalkingRunning" -> readRecordType<DistanceRecord>(hcClient, typeId, sinceTimestamp, limit) { convertDistance(it) }
-                "water", "dietaryWater" -> readRecordType<HydrationRecord>(hcClient, typeId, sinceTimestamp, limit) { convertHydration(it) }
-                "vo2Max" -> readRecordType<Vo2MaxRecord>(hcClient, typeId, sinceTimestamp, limit) { convertVo2Max(it) }
-                "respiratoryRate" -> readRecordType<RespiratoryRateRecord>(hcClient, typeId, sinceTimestamp, limit) { convertRespiratoryRate(it) }
-                "distanceCycling" -> readRecordType<DistanceRecord>(hcClient, typeId, sinceTimestamp, limit) { convertDistance(it) }
-                "workout" -> readWorkouts(hcClient, sinceTimestamp, limit)
-                "sleep" -> readSleep(hcClient, sinceTimestamp, limit)
-                else -> ProviderReadResult(UnifiedHealthData(), null)
-            }
-        } catch (e: SecurityException) {
-            logger("  $typeId: missing permission, skipping")
-            ProviderReadResult(UnifiedHealthData(), null)
-        } catch (e: Exception) {
-            logger("Failed to read $typeId from Health Connect: ${e.javaClass.simpleName}: ${e.message}")
-            ProviderReadResult(UnifiedHealthData(), null)
-        }
-    }
+    ): ProviderReadResult = readRecordsInternal(
+        typeId = typeId,
+        sinceTimestamp = sinceTimestamp,
+        olderThanTimestamp = null,
+        limit = limit,
+        ascending = true
+    )
 
     override suspend fun readDataDescending(
         typeId: String,
         olderThanTimestamp: Long?,
         limit: Int
-    ): ProviderReadResult = withContext(Dispatchers.IO) {
-        if (client == null) withContext(Dispatchers.Main) { connect() }
+    ): ProviderReadResult = readRecordsInternal(
+        typeId = typeId,
+        sinceTimestamp = null,
+        olderThanTimestamp = olderThanTimestamp,
+        limit = limit,
+        ascending = false
+    )
+
+    private suspend fun readRecordsInternal(
+        typeId: String,
+        sinceTimestamp: Long?,
+        olderThanTimestamp: Long?,
+        limit: Int,
+        ascending: Boolean
+    ): ProviderReadResult = withContext(dispatchers.io) {
+        if (client == null) withContext(dispatchers.main) { connect() }
         val hcClient = client ?: return@withContext ProviderReadResult(UnifiedHealthData(), null, null)
 
         try {
             when (typeId) {
-                "steps" -> readRecordType<StepsRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertSteps(it) }
-                "heartRate" -> readRecordType<HeartRateRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertHeartRate(it) }
-                "restingHeartRate" -> readRecordType<RestingHeartRateRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertRestingHeartRate(it) }
-                "heartRateVariabilitySDNN" -> readRecordType<HeartRateVariabilityRmssdRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertHrv(it) }
-                "oxygenSaturation" -> readRecordType<OxygenSaturationRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertOxygenSaturation(it) }
-                "bloodPressure", "bloodPressureSystolic", "bloodPressureDiastolic" -> readRecordType<BloodPressureRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertBloodPressure(it) }
-                "bloodGlucose" -> readRecordType<BloodGlucoseRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertBloodGlucose(it) }
-                "activeEnergy" -> readRecordType<ActiveCaloriesBurnedRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertActiveCalories(it) }
-                "basalEnergy" -> readRecordType<BasalMetabolicRateRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertBasalCalories(it) }
-                "bodyTemperature" -> readRecordType<BodyTemperatureRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertBodyTemperature(it) }
-                "bodyMass" -> readRecordType<WeightRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertWeight(it) }
-                "height" -> readRecordType<HeightRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertHeight(it) }
-                "bodyFatPercentage" -> readRecordType<BodyFatRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertBodyFat(it) }
-                "leanBodyMass" -> readRecordType<LeanBodyMassRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertLeanBodyMass(it) }
-                "flightsClimbed" -> readRecordType<FloorsClimbedRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertFloors(it) }
-                "distanceWalkingRunning" -> readRecordType<DistanceRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertDistance(it) }
-                "water", "dietaryWater" -> readRecordType<HydrationRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertHydration(it) }
-                "vo2Max" -> readRecordType<Vo2MaxRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertVo2Max(it) }
-                "respiratoryRate" -> readRecordType<RespiratoryRateRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertRespiratoryRate(it) }
-                "distanceCycling" -> readRecordType<DistanceRecord>(hcClient, typeId, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp) { convertDistance(it) }
-                "workout" -> readWorkouts(hcClient, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp)
-                "sleep" -> readSleep(hcClient, null, limit, ascending = false, olderThanTimestamp = olderThanTimestamp)
+                "steps" -> readRecordType<StepsRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertSteps(it) }
+                "heartRate" -> readRecordType<HeartRateRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertHeartRate(it) }
+                "restingHeartRate" -> readRecordType<RestingHeartRateRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertRestingHeartRate(it) }
+                "heartRateVariabilitySDNN" -> readRecordType<HeartRateVariabilityRmssdRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertHrv(it) }
+                "oxygenSaturation" -> readRecordType<OxygenSaturationRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertOxygenSaturation(it) }
+                "bloodPressure", "bloodPressureSystolic", "bloodPressureDiastolic" -> readRecordType<BloodPressureRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertBloodPressure(it) }
+                "bloodGlucose" -> readRecordType<BloodGlucoseRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertBloodGlucose(it) }
+                "activeEnergy" -> readRecordType<ActiveCaloriesBurnedRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertActiveCalories(it) }
+                "basalEnergy" -> readRecordType<BasalMetabolicRateRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertBasalCalories(it) }
+                "bodyTemperature" -> readRecordType<BodyTemperatureRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertBodyTemperature(it) }
+                "bodyMass" -> readRecordType<WeightRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertWeight(it) }
+                "height" -> readRecordType<HeightRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertHeight(it) }
+                "bodyFatPercentage" -> readRecordType<BodyFatRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertBodyFat(it) }
+                "leanBodyMass" -> readRecordType<LeanBodyMassRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertLeanBodyMass(it) }
+                "flightsClimbed" -> readRecordType<FloorsClimbedRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertFloors(it) }
+                "distanceWalkingRunning" -> readRecordType<DistanceRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertDistance(it) }
+                "water", "dietaryWater" -> readRecordType<HydrationRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertHydration(it) }
+                "vo2Max" -> readRecordType<Vo2MaxRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertVo2Max(it) }
+                "respiratoryRate" -> readRecordType<RespiratoryRateRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertRespiratoryRate(it) }
+                "distanceCycling" -> readRecordType<DistanceRecord>(hcClient, typeId, sinceTimestamp, limit, ascending, olderThanTimestamp) { convertDistance(it) }
+                "workout" -> readWorkouts(hcClient, sinceTimestamp, limit, ascending, olderThanTimestamp)
+                "sleep" -> readSleep(hcClient, sinceTimestamp, limit, ascending, olderThanTimestamp)
                 else -> ProviderReadResult(UnifiedHealthData(), null, null)
             }
         } catch (e: SecurityException) {
             logger("  $typeId: missing permission, skipping")
             ProviderReadResult(UnifiedHealthData(), null, null)
         } catch (e: Exception) {
-            logger("Failed to read $typeId (descending) from Health Connect: ${e.javaClass.simpleName}: ${e.message}")
+            logger("Failed to read $typeId from Health Connect: ${e.javaClass.simpleName}: ${e.message}")
             ProviderReadResult(UnifiedHealthData(), null, null)
         }
     }
@@ -329,7 +327,6 @@ class HealthConnectManager(
 
     private fun instantToIso(instant: Instant): String = UnifiedTimestamp.fromEpochMs(instant.toEpochMilli())
 
-    // ---- Steps ----
     private fun convertSteps(records: List<StepsRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = records.map { r ->
@@ -340,7 +337,6 @@ class HealthConnectManager(
         return ProviderReadResult(UnifiedHealthData(records = unified), maxTs)
     }
 
-    // ---- Heart Rate (split samples) ----
     private fun convertHeartRate(records: List<HeartRateRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = mutableListOf<UnifiedRecord>()
@@ -358,7 +354,6 @@ class HealthConnectManager(
         return ProviderReadResult(UnifiedHealthData(records = unified), maxTs)
     }
 
-    // ---- Resting Heart Rate ----
     private fun convertRestingHeartRate(records: List<RestingHeartRateRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = records.map { r ->
@@ -370,7 +365,6 @@ class HealthConnectManager(
         return ProviderReadResult(UnifiedHealthData(records = unified), maxTs)
     }
 
-    // ---- HRV ----
     private fun convertHrv(records: List<HeartRateVariabilityRmssdRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = records.map { r ->
@@ -382,7 +376,6 @@ class HealthConnectManager(
         return ProviderReadResult(UnifiedHealthData(records = unified), maxTs)
     }
 
-    // ---- Oxygen Saturation ----
     private fun convertOxygenSaturation(records: List<OxygenSaturationRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = records.map { r ->
@@ -394,7 +387,6 @@ class HealthConnectManager(
         return ProviderReadResult(UnifiedHealthData(records = unified), maxTs)
     }
 
-    // ---- Blood Pressure (split) ----
     private fun convertBloodPressure(records: List<BloodPressureRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = mutableListOf<UnifiedRecord>()
@@ -434,7 +426,6 @@ class HealthConnectManager(
         else -> "unknown"
     }
 
-    // ---- Blood Glucose ----
     private fun convertBloodGlucose(records: List<BloodGlucoseRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = records.map { r ->
@@ -469,7 +460,6 @@ class HealthConnectManager(
         else -> "unknown"
     }
 
-    // ---- Active Calories ----
     private fun convertActiveCalories(records: List<ActiveCaloriesBurnedRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = records.map { r ->
@@ -480,7 +470,6 @@ class HealthConnectManager(
         return ProviderReadResult(UnifiedHealthData(records = unified), maxTs)
     }
 
-    // ---- Basal Metabolic Rate ----
     private fun convertBasalCalories(records: List<BasalMetabolicRateRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = records.map { r ->
@@ -492,7 +481,6 @@ class HealthConnectManager(
         return ProviderReadResult(UnifiedHealthData(records = unified), maxTs)
     }
 
-    // ---- Body Temperature ----
     private fun convertBodyTemperature(records: List<BodyTemperatureRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = records.map { r ->
@@ -507,20 +495,11 @@ class HealthConnectManager(
     }
 
     private fun mapTempLocation(loc: Int): String = when (loc) {
-        1 -> "armpit"
-        2 -> "finger"
-        3 -> "forehead"
-        4 -> "mouth"
-        5 -> "rectum"
-        6 -> "temporal_artery"
-        7 -> "toe"
-        8 -> "ear"
-        9 -> "wrist"
-        10 -> "vagina"
+        1 -> "armpit"; 2 -> "finger"; 3 -> "forehead"; 4 -> "mouth"; 5 -> "rectum"
+        6 -> "temporal_artery"; 7 -> "toe"; 8 -> "ear"; 9 -> "wrist"; 10 -> "vagina"
         else -> "unknown"
     }
 
-    // ---- Weight ----
     private fun convertWeight(records: List<WeightRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = records.map { r ->
@@ -532,7 +511,6 @@ class HealthConnectManager(
         return ProviderReadResult(UnifiedHealthData(records = unified), maxTs)
     }
 
-    // ---- Height ----
     private fun convertHeight(records: List<HeightRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = records.map { r ->
@@ -544,7 +522,6 @@ class HealthConnectManager(
         return ProviderReadResult(UnifiedHealthData(records = unified), maxTs)
     }
 
-    // ---- Body Fat ----
     private fun convertBodyFat(records: List<BodyFatRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = records.map { r ->
@@ -556,7 +533,6 @@ class HealthConnectManager(
         return ProviderReadResult(UnifiedHealthData(records = unified), maxTs)
     }
 
-    // ---- Lean Body Mass ----
     private fun convertLeanBodyMass(records: List<LeanBodyMassRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = records.map { r ->
@@ -568,7 +544,6 @@ class HealthConnectManager(
         return ProviderReadResult(UnifiedHealthData(records = unified), maxTs)
     }
 
-    // ---- Floors Climbed ----
     private fun convertFloors(records: List<FloorsClimbedRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = records.map { r ->
@@ -579,7 +554,6 @@ class HealthConnectManager(
         return ProviderReadResult(UnifiedHealthData(records = unified), maxTs)
     }
 
-    // ---- Distance ----
     private fun convertDistance(records: List<DistanceRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = records.map { r ->
@@ -590,7 +564,6 @@ class HealthConnectManager(
         return ProviderReadResult(UnifiedHealthData(records = unified), maxTs)
     }
 
-    // ---- Hydration (L → mL) ----
     private fun convertHydration(records: List<HydrationRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = records.map { r ->
@@ -601,7 +574,6 @@ class HealthConnectManager(
         return ProviderReadResult(UnifiedHealthData(records = unified), maxTs)
     }
 
-    // ---- Respiratory Rate ----
     private fun convertRespiratoryRate(records: List<RespiratoryRateRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = records.map { r ->
@@ -613,7 +585,6 @@ class HealthConnectManager(
         return ProviderReadResult(UnifiedHealthData(records = unified), maxTs)
     }
 
-    // ---- VO2 Max ----
     private fun convertVo2Max(records: List<Vo2MaxRecord>): ProviderReadResult {
         var maxTs: Long? = null
         val unified = records.map { r ->
@@ -847,22 +818,18 @@ class HealthConnectManager(
                 val zo = zoneStr(r.startZoneOffset)
                 val parentId = r.metadata.id
 
-                logger("  Sleep session $parentId: ${instantToIso(r.startTime)} → ${instantToIso(r.endTime)}")
-
                 val stages = try { r.stages } catch (e: Exception) {
                     logger("  Failed to read stages for $parentId: ${e.message}")
                     emptyList()
                 }
 
                 if (stages.isEmpty()) {
-                    logger("  No stages, adding as single 'sleeping' entry")
                     sleepEntries.add(UnifiedSleep(
                         parentId, null, "sleeping",
                         instantToIso(r.startTime), instantToIso(r.endTime),
                         zo, source, null, null
                     ))
                 } else {
-                    logger("  ${stages.size} stages found")
                     for ((idx, stage) in stages.withIndex()) {
                         sleepEntries.add(UnifiedSleep(
                             id = "$parentId-s$idx",

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/HealthDataProvider.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/HealthDataProvider.kt
@@ -27,7 +27,11 @@ interface HealthDataProvider {
     /** Release any held resources. */
     fun disconnect()
 
-    /** Provide the current Activity (needed for permission dialogs). */
+    /**
+     * Provide the current Activity (needed for permission dialogs).
+     * Implementations should store this as a [java.lang.ref.WeakReference]
+     * to prevent Activity leaks in singleton-scoped objects.
+     */
     fun setActivity(activity: Activity?)
 
     /** Configure which Flutter-side type IDs should be tracked. */

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/HealthSyncWorker.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/HealthSyncWorker.kt
@@ -1,0 +1,95 @@
+package com.openwearables.health.sdk
+
+import android.content.Context
+import androidx.work.*
+
+/**
+ * WorkManager worker for background health data synchronization.
+ *
+ * Scheduled as a [PeriodicWorkRequest] by [SyncManager]. The worker does NOT
+ * manually schedule the next run — WorkManager handles periodic re-execution.
+ */
+class HealthSyncWorker(
+    context: Context,
+    params: WorkerParameters
+) : CoroutineWorker(context, params) {
+
+    companion object {
+        const val KEY_HOST = "host"
+        const val KEY_CUSTOM_SYNC_URL = "customSyncUrl"
+    }
+
+    override suspend fun doWork(): Result {
+        val host = inputData.getString(KEY_HOST) ?: return Result.failure()
+        val customSyncUrl = inputData.getString(KEY_CUSTOM_SYNC_URL)
+
+        try {
+            setForeground(getForegroundInfo())
+            android.util.Log.d("HealthSyncWorker", "Running as foreground service")
+        } catch (e: Exception) {
+            android.util.Log.w("HealthSyncWorker", "Could not promote to foreground: ${e.message}")
+        }
+
+        val secureStorage = SecureStorage(applicationContext)
+        val dispatchers = DefaultDispatcherProvider()
+        val provider = createProvider(applicationContext, secureStorage, dispatchers)
+        val syncManager = SyncManager(
+            applicationContext, secureStorage, provider, dispatchers,
+            { android.util.Log.d("HealthSyncWorker", it) }
+        )
+
+        return try {
+            val trackedTypes = secureStorage.getTrackedTypes()
+            provider.setTrackedTypes(trackedTypes)
+
+            android.util.Log.d("HealthSyncWorker", "Background sync (provider: ${provider.providerId})")
+            syncManager.syncNow(host, customSyncUrl, fullExport = false)
+
+            Result.success()
+        } catch (e: Exception) {
+            android.util.Log.e("HealthSyncWorker", "Sync failed", e)
+            Result.retry()
+        }
+    }
+
+    private fun createProvider(
+        context: Context,
+        storage: SecureStorage,
+        dispatchers: DispatcherProvider
+    ): HealthDataProvider {
+        val providerId = storage.getProvider()
+        val log: (String) -> Unit = { android.util.Log.d("HealthSyncWorker", it) }
+        return when (providerId) {
+            ProviderIds.GOOGLE -> HealthConnectManager(context, null, dispatchers, log)
+            else -> SamsungHealthManager(context, null, dispatchers, log)
+        }
+    }
+
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        createNotificationChannel()
+        val notification = androidx.core.app.NotificationCompat.Builder(applicationContext, NotificationConfig.CHANNEL_ID)
+            .setContentTitle(NotificationConfig.CHANNEL_NAME)
+            .setContentText("Syncing health data...")
+            .setSmallIcon(android.R.drawable.ic_popup_sync)
+            .setPriority(androidx.core.app.NotificationCompat.PRIORITY_LOW)
+            .setOngoing(true)
+            .build()
+        return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            ForegroundInfo(NotificationConfig.NOTIFICATION_ID, notification, android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        } else {
+            ForegroundInfo(NotificationConfig.NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun createNotificationChannel() {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            val channel = android.app.NotificationChannel(
+                NotificationConfig.CHANNEL_ID,
+                NotificationConfig.CHANNEL_NAME,
+                android.app.NotificationManager.IMPORTANCE_LOW
+            ).apply { description = NotificationConfig.CHANNEL_DESCRIPTION }
+            (applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager)
+                .createNotificationChannel(channel)
+        }
+    }
+}

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/OpenWearablesHealthSDK.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/OpenWearablesHealthSDK.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.util.Log
 import kotlinx.coroutines.*
+import java.lang.ref.WeakReference
 
 /**
  * Main entry point for the Open Wearables Health SDK.
@@ -20,7 +21,12 @@ import kotlinx.coroutines.*
  * sdk.startBackgroundSync()
  * ```
  */
-class OpenWearablesHealthSDK private constructor(private val context: Context) {
+class OpenWearablesHealthSDK private constructor(
+    private val context: Context,
+    private val dispatchers: DispatcherProvider = DefaultDispatcherProvider(),
+    samsungHealthManagerFactory: ((Context, Activity?, DispatcherProvider, (String) -> Unit) -> SamsungHealthManager)? = null,
+    healthConnectManagerFactory: ((Context, Activity?, DispatcherProvider, (String) -> Unit) -> HealthConnectManager)? = null
+) {
 
     companion object {
         private const val TAG = "OpenWearablesHealthSDK"
@@ -28,9 +34,28 @@ class OpenWearablesHealthSDK private constructor(private val context: Context) {
         @Volatile
         private var instance: OpenWearablesHealthSDK? = null
 
-        fun initialize(context: Context): OpenWearablesHealthSDK {
+        fun initialize(
+            context: Context,
+            dispatchers: DispatcherProvider = DefaultDispatcherProvider()
+        ): OpenWearablesHealthSDK {
             return instance ?: synchronized(this) {
-                instance ?: OpenWearablesHealthSDK(context.applicationContext).also { instance = it }
+                instance ?: OpenWearablesHealthSDK(context.applicationContext, dispatchers).also { instance = it }
+            }
+        }
+
+        /**
+         * Initialize with custom factories for testability. Allows injecting mock managers.
+         */
+        internal fun initializeForTesting(
+            context: Context,
+            dispatchers: DispatcherProvider,
+            samsungFactory: ((Context, Activity?, DispatcherProvider, (String) -> Unit) -> SamsungHealthManager)? = null,
+            healthConnectFactory: ((Context, Activity?, DispatcherProvider, (String) -> Unit) -> HealthConnectManager)? = null
+        ): OpenWearablesHealthSDK {
+            return synchronized(this) {
+                OpenWearablesHealthSDK(context.applicationContext, dispatchers, samsungFactory, healthConnectFactory).also {
+                    instance = it
+                }
             }
         }
 
@@ -49,10 +74,12 @@ class OpenWearablesHealthSDK private constructor(private val context: Context) {
     internal val secureStorage: SecureStorage by lazy { SecureStorage(context) }
 
     private val samsungHealthManager: SamsungHealthManager by lazy {
-        SamsungHealthManager(context, activity, ::logMessage)
+        samsungHealthManagerFactory?.invoke(context, activityRef?.get(), dispatchers, ::logMessage)
+            ?: SamsungHealthManager(context, activityRef?.get(), dispatchers, ::logMessage)
     }
     private val healthConnectManager: HealthConnectManager by lazy {
-        HealthConnectManager(context, activity, ::logMessage)
+        healthConnectManagerFactory?.invoke(context, activityRef?.get(), dispatchers, ::logMessage)
+            ?: HealthConnectManager(context, activityRef?.get(), dispatchers, ::logMessage)
     }
 
     private var activeProvider: HealthDataProvider? = null
@@ -62,18 +89,18 @@ class OpenWearablesHealthSDK private constructor(private val context: Context) {
     private var host: String? = null
     private var customSyncUrl: String? = null
 
-    // Activity reference for permission dialogs
-    private var activity: Activity? = null
+    // Activity reference via WeakReference to prevent memory leaks
+    private var activityRef: WeakReference<Activity>? = null
 
-    // Coroutine scope
-    private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+    // Coroutine scope — recreated if destroy() was called
+    private var scope = CoroutineScope(dispatchers.main + SupervisorJob())
 
     // -----------------------------------------------------------------------
     // Activity
     // -----------------------------------------------------------------------
 
     fun setActivity(activity: Activity?) {
-        this.activity = activity
+        this.activityRef = activity?.let { WeakReference(it) }
         samsungHealthManager.setActivity(activity)
         healthConnectManager.setActivity(activity)
     }
@@ -114,6 +141,14 @@ class OpenWearablesHealthSDK private constructor(private val context: Context) {
         }
 
         return isSyncActive
+    }
+
+    /**
+     * Set the background sync interval in minutes. Minimum is 15 (Android limit).
+     */
+    fun setSyncInterval(minutes: Long) {
+        ensureSyncManager().syncIntervalMinutes = minutes
+        logMessage("Sync interval set to ${maxOf(minutes, SyncDefaults.MIN_SYNC_INTERVAL_MINUTES)} minutes")
     }
 
     private suspend fun autoRestoreSync() {
@@ -265,8 +300,8 @@ class OpenWearablesHealthSDK private constructor(private val context: Context) {
 
     fun setProvider(providerId: String): Boolean {
         val provider = when (providerId) {
-            "samsung" -> samsungHealthManager
-            "google" -> healthConnectManager
+            ProviderIds.SAMSUNG -> samsungHealthManager
+            ProviderIds.GOOGLE -> healthConnectManager
             else -> {
                 logMessage("Unknown provider: $providerId")
                 return false
@@ -287,13 +322,13 @@ class OpenWearablesHealthSDK private constructor(private val context: Context) {
 
     fun getAvailableProviders(): List<Map<String, Any>> = listOf(
         mapOf(
-            "id" to "samsung",
-            "displayName" to "Samsung Health",
+            "id" to ProviderIds.SAMSUNG,
+            "displayName" to ProviderDisplayNames.SAMSUNG_HEALTH,
             "isAvailable" to samsungHealthManager.isAvailable()
         ),
         mapOf(
-            "id" to "google",
-            "displayName" to "Health Connect",
+            "id" to ProviderIds.GOOGLE,
+            "displayName" to ProviderDisplayNames.HEALTH_CONNECT,
             "isAvailable" to healthConnectManager.isAvailable()
         )
     )
@@ -331,6 +366,9 @@ class OpenWearablesHealthSDK private constructor(private val context: Context) {
     fun destroy() {
         activeProvider?.disconnect()
         scope.cancel()
+        synchronized(Companion) {
+            instance = null
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -347,8 +385,8 @@ class OpenWearablesHealthSDK private constructor(private val context: Context) {
     }
 
     private fun resolveProvider(providerId: String?): HealthDataProvider = when (providerId) {
-        "google" -> healthConnectManager
-        "samsung" -> samsungHealthManager
+        ProviderIds.GOOGLE -> healthConnectManager
+        ProviderIds.SAMSUNG -> samsungHealthManager
         else -> autoSelectProvider()
     }
 
@@ -360,9 +398,10 @@ class OpenWearablesHealthSDK private constructor(private val context: Context) {
 
     private fun rebuildSyncManager() {
         val provider = activeProvider ?: return
-        syncManager = SyncManager(context, secureStorage, provider, ::logMessage, ::emitAuthError)
+        syncManager = SyncManager(context, secureStorage, provider, dispatchers, ::logMessage, ::emitAuthError)
     }
 
+    @Synchronized
     internal fun ensureSyncManager(): SyncManager {
         if (syncManager == null) {
             getOrCreateProvider()

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/Outcome.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/Outcome.kt
@@ -1,0 +1,31 @@
+package com.openwearables.health.sdk
+
+/**
+ * A generic result wrapper that forces callers to handle both success and error cases.
+ * Replaces silent exception swallowing throughout the SDK.
+ */
+sealed class Outcome<out T> {
+    data class Success<T>(val value: T) : Outcome<T>()
+    data class Error(val exception: Throwable, val message: String? = null) : Outcome<Nothing>()
+
+    val isSuccess: Boolean get() = this is Success
+    val isError: Boolean get() = this is Error
+
+    fun getOrNull(): T? = when (this) {
+        is Success -> value
+        is Error -> null
+    }
+
+    fun exceptionOrNull(): Throwable? = when (this) {
+        is Success -> null
+        is Error -> exception
+    }
+
+    inline fun <R> fold(
+        onSuccess: (T) -> R,
+        onError: (Throwable, String?) -> R
+    ): R = when (this) {
+        is Success -> onSuccess(value)
+        is Error -> onError(exception, message)
+    }
+}

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/SamsungHealthManager.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/SamsungHealthManager.kt
@@ -19,8 +19,8 @@ import com.samsung.android.sdk.health.data.request.LocalTimeFilter
 import com.samsung.android.sdk.health.data.request.Ordering
 import com.samsung.android.sdk.health.data.request.AggregateRequest
 import com.samsung.android.sdk.health.data.request.ReadDataRequest
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.lang.ref.WeakReference
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -28,17 +28,19 @@ import java.util.*
 
 class SamsungHealthManager(
     private val context: Context,
-    private var activity: Activity?,
+    activity: Activity?,
+    private val dispatchers: DispatcherProvider,
     private val logger: (String) -> Unit
 ) : HealthDataProvider {
 
-    override val providerId = "samsung"
-    override val providerName = "Samsung Health"
+    override val providerId = ProviderIds.SAMSUNG
+    override val providerName = ProviderDisplayNames.SAMSUNG_HEALTH
 
     private var healthDataStore: HealthDataStore? = null
     private var deviceManager: DeviceManager? = null
     private var trackedTypeIds: Set<String> = emptySet()
     private var deviceCache: MutableMap<String, Device> = mutableMapOf()
+    private var activityRef: WeakReference<Activity>? = activity?.let { WeakReference(it) }
 
     companion object {
         private const val SAMSUNG_HEALTH_PACKAGE = "com.sec.android.app.shealth"
@@ -50,7 +52,7 @@ class SamsungHealthManager(
     // -----------------------------------------------------------------------
 
     override fun setActivity(activity: Activity?) {
-        this.activity = activity
+        this.activityRef = activity?.let { WeakReference(it) }
     }
 
     override fun setTrackedTypes(typeIds: List<String>) {
@@ -72,11 +74,35 @@ class SamsungHealthManager(
         } catch (e: PackageManager.NameNotFoundException) {
             false
         } catch (e: Exception) {
+            logger("Samsung Health availability check failed: ${e.javaClass.simpleName}: ${e.message}")
             false
         }
     }
 
-    override suspend fun connect(): Boolean = withContext(Dispatchers.Main) {
+    /**
+     * Returns detailed availability info with error reporting via [Outcome].
+     */
+    fun isAvailableDetailed(): Outcome<Boolean> {
+        return try {
+            val packageInfo = context.packageManager.getPackageInfo(SAMSUNG_HEALTH_PACKAGE, 0)
+            @Suppress("DEPRECATION")
+            val versionCode = packageInfo.versionCode
+            if (versionCode >= MIN_SAMSUNG_HEALTH_VERSION) {
+                Outcome.Success(true)
+            } else {
+                Outcome.Error(
+                    IllegalStateException("Samsung Health version $versionCode < $MIN_SAMSUNG_HEALTH_VERSION"),
+                    "Samsung Health version too old"
+                )
+            }
+        } catch (e: PackageManager.NameNotFoundException) {
+            Outcome.Success(false)
+        } catch (e: Exception) {
+            Outcome.Error(e, "Failed to check Samsung Health availability")
+        }
+    }
+
+    override suspend fun connect(): Boolean = withContext(dispatchers.io) {
         if (!isAvailable()) {
             logger("Samsung Health not available on this device")
             return@withContext false
@@ -109,12 +135,12 @@ class SamsungHealthManager(
         if (healthDataStore == null && !connect()) return false
 
         val store = healthDataStore ?: return false
-        val act = activity ?: run {
+        val act = activityRef?.get() ?: run {
             logger("Activity not available for permission request")
             return false
         }
 
-        return withContext(Dispatchers.Main) {
+        return withContext(dispatchers.main) {
             try {
                 val permissions = dataTypes.map { Permission.of(it, AccessType.READ) }.toSet()
                 logger("Requesting ${permissions.size} Samsung Health permissions...")
@@ -160,7 +186,7 @@ class SamsungHealthManager(
         typeId: String,
         sinceTimestamp: Long?,
         limit: Int
-    ): List<HealthDataRecord> = withContext(Dispatchers.IO) {
+    ): List<HealthDataRecord> = withContext(dispatchers.io) {
         val aggregateConfig = getAggregateConfig(typeId)
         if (aggregateConfig != null) {
             return@withContext readAggregateData(typeId, aggregateConfig, sinceTimestamp, limit)
@@ -171,7 +197,7 @@ class SamsungHealthManager(
             logger("[$typeId] mapToDataType returned null — unknown type")
             return@withContext emptyList()
         }
-        if (healthDataStore == null) withContext(Dispatchers.Main) { connect() }
+        if (healthDataStore == null) withContext(dispatchers.io) { connect() }
         val store = healthDataStore
         if (store == null) {
             logger("[$typeId] healthDataStore is null after connect attempt")
@@ -191,8 +217,6 @@ class SamsungHealthManager(
                 val parsed = parseDataPoint(typeId, dp as HealthDataPoint)
                 if (parsed == null) {
                     logger("[$typeId] parseDataPoint returned null for uid=${dp.uid}")
-                } else {
-                    logger("[$typeId] Parsed record uid=${parsed.uid}, fields=${parsed.fields}")
                 }
                 parsed
             }
@@ -208,7 +232,7 @@ class SamsungHealthManager(
         typeId: String,
         olderThanTimestamp: Long?,
         limit: Int
-    ): List<HealthDataRecord> = withContext(Dispatchers.IO) {
+    ): List<HealthDataRecord> = withContext(dispatchers.io) {
         val aggregateConfig = getAggregateConfig(typeId)
         if (aggregateConfig != null) {
             return@withContext readAggregateDataDescending(typeId, aggregateConfig, olderThanTimestamp, limit)
@@ -219,7 +243,7 @@ class SamsungHealthManager(
             logger("[$typeId] mapToDataType returned null — unknown type")
             return@withContext emptyList()
         }
-        if (healthDataStore == null) withContext(Dispatchers.Main) { connect() }
+        if (healthDataStore == null) withContext(dispatchers.io) { connect() }
         val store = healthDataStore
         if (store == null) {
             logger("[$typeId] healthDataStore is null after connect attempt")
@@ -265,7 +289,7 @@ class SamsungHealthManager(
         sinceTimestamp: Long?,
         limit: Int
     ): List<HealthDataRecord> {
-        if (healthDataStore == null) withContext(Dispatchers.Main) { connect() }
+        if (healthDataStore == null) withContext(dispatchers.io) { connect() }
         val store = healthDataStore
         if (store == null) {
             logger("[$typeId] healthDataStore is null")
@@ -295,7 +319,6 @@ class SamsungHealthManager(
             val builderClass = builder.javaClass
             logger("[$typeId] Got builder: ${builderClass.name}")
 
-            // Time filter
             val startTime = if (sinceTimestamp != null) {
                 LocalDateTime.ofInstant(Instant.ofEpochMilli(sinceTimestamp + 1), ZoneId.systemDefault())
             } else {
@@ -356,7 +379,7 @@ class SamsungHealthManager(
         olderThanTimestamp: Long?,
         limit: Int
     ): List<HealthDataRecord> {
-        if (healthDataStore == null) withContext(Dispatchers.Main) { connect() }
+        if (healthDataStore == null) withContext(dispatchers.io) { connect() }
         val store = healthDataStore
         if (store == null) {
             logger("[$typeId] healthDataStore is null")
@@ -418,7 +441,6 @@ class SamsungHealthManager(
     }
 
     private fun findAggregateOp(typeId: String, dataType: DataType, opName: String): Any? {
-        // Try 1: Companion getter (e.g. Companion.getTOTAL())
         try {
             val companionField = dataType.javaClass.getField("Companion")
             val companion = companionField.get(dataType)
@@ -434,7 +456,6 @@ class SamsungHealthManager(
             logger("[$typeId] Companion.$opName failed: ${e.message}")
         }
 
-        // Try 2: static field
         try {
             val field = dataType.javaClass.getField(opName)
             val op = field.get(dataType)
@@ -446,7 +467,6 @@ class SamsungHealthManager(
             logger("[$typeId] Static field $opName failed: ${e.message}")
         }
 
-        // Try 3: getAllAggregateOperations — match by name or pick first
         try {
             val allOps = dataType.javaClass.getMethod("getAllAggregateOperations").invoke(dataType)
             if (allOps is Collection<*> && allOps.isNotEmpty()) {
@@ -866,7 +886,7 @@ class SamsungHealthManager(
     )
 
     // -----------------------------------------------------------------------
-    // Samsung SDK internals (unchanged logic)
+    // Samsung SDK internals
     // -----------------------------------------------------------------------
 
     private fun mapToDataType(typeId: String): DataType? {
@@ -1116,107 +1136,121 @@ class SamsungHealthManager(
         else -> emptyMap()
     }
 
-    // ---- field extractors ----
+    // ---- field extractors (using direct SDK field access where possible) ----
 
     private fun extractHeartRateFields(dp: HealthDataPoint): Map<String, Any?> {
-        val f = mutableMapOf<String, Any?>()
-        getFieldValue<Float>(DataTypes.HEART_RATE, "HEART_RATE", dp)?.let { f["HEART_RATE"] = it }
-        getFieldValue<Any>(DataTypes.HEART_RATE, "HEART_RATE_STATUS", dp)?.let { f["HEART_RATE_STATUS"] = if (it is Enum<*>) it.name else it.toString() }
-        return f
+        val fields = mutableMapOf<String, Any?>()
+        getFieldValue<Float>(DataTypes.HEART_RATE, "HEART_RATE", dp)?.let { fields["HEART_RATE"] = it }
+        getFieldValue<Any>(DataTypes.HEART_RATE, "HEART_RATE_STATUS", dp)?.let { fields["HEART_RATE_STATUS"] = if (it is Enum<*>) it.name else it.toString() }
+        return fields
     }
 
     private fun extractStepsFields(dp: HealthDataPoint): Map<String, Any?> {
-        val f = mutableMapOf<String, Any?>()
+        val fields = mutableMapOf<String, Any?>()
         val totalLong = getFieldValue<Long>(DataTypes.STEPS, "TOTAL", dp)
-        val totalInt = getFieldValue<Int>(DataTypes.STEPS, "TOTAL", dp)
-        val totalFloat = getFieldValue<Float>(DataTypes.STEPS, "TOTAL", dp)
         val totalAny = getFieldValue<Any>(DataTypes.STEPS, "TOTAL", dp)
-        logger("[steps] extractStepsFields: TOTAL as Long=$totalLong, Int=$totalInt, Float=$totalFloat, Any=$totalAny (type=${totalAny?.javaClass?.simpleName})")
+        logger("[steps] extractStepsFields: TOTAL as Long=$totalLong, Any=$totalAny (type=${totalAny?.javaClass?.simpleName})")
         if (totalLong != null) {
-            f["TOTAL"] = totalLong
+            fields["TOTAL"] = totalLong
         } else if (totalAny is Number) {
             logger("[steps] TOTAL fallback via Number: ${totalAny.toLong()}")
-            f["TOTAL"] = totalAny.toLong()
+            fields["TOTAL"] = totalAny.toLong()
         }
-        return f
+        return fields
     }
 
     private fun extractBloodOxygenFields(dp: HealthDataPoint): Map<String, Any?> {
-        val f = mutableMapOf<String, Any?>()
-        getFieldValue<Float>(DataTypes.BLOOD_OXYGEN, "OXYGEN_SATURATION", dp)?.let { f["OXYGEN_SATURATION"] = it }
-        return f
+        val fields = mutableMapOf<String, Any?>()
+        getFieldValue<Float>(DataTypes.BLOOD_OXYGEN, "OXYGEN_SATURATION", dp)?.let { fields["OXYGEN_SATURATION"] = it }
+        return fields
     }
 
     private fun extractBloodGlucoseFields(dp: HealthDataPoint): Map<String, Any?> {
-        val f = mutableMapOf<String, Any?>()
-        getFieldValue<Float>(DataTypes.BLOOD_GLUCOSE, "LEVEL", dp)?.let { f["LEVEL"] = it }
-        getFieldValue<Any>(DataTypes.BLOOD_GLUCOSE, "MEAL_STATUS", dp)?.let { f["MEAL_STATUS"] = if (it is Enum<*>) it.name else it.toString() }
-        getFieldValue<Any>(DataTypes.BLOOD_GLUCOSE, "MEASUREMENT_TYPE", dp)?.let { f["MEASUREMENT_TYPE"] = if (it is Enum<*>) it.name else it.toString() }
-        getFieldValue<Any>(DataTypes.BLOOD_GLUCOSE, "SAMPLE_SOURCE_TYPE", dp)?.let { f["SAMPLE_SOURCE_TYPE"] = if (it is Enum<*>) it.name else it.toString() }
-        return f
+        val fields = mutableMapOf<String, Any?>()
+        getFieldValue<Float>(DataTypes.BLOOD_GLUCOSE, "LEVEL", dp)?.let { fields["LEVEL"] = it }
+        getFieldValue<Any>(DataTypes.BLOOD_GLUCOSE, "MEAL_STATUS", dp)?.let { fields["MEAL_STATUS"] = if (it is Enum<*>) it.name else it.toString() }
+        getFieldValue<Any>(DataTypes.BLOOD_GLUCOSE, "MEASUREMENT_TYPE", dp)?.let { fields["MEASUREMENT_TYPE"] = if (it is Enum<*>) it.name else it.toString() }
+        getFieldValue<Any>(DataTypes.BLOOD_GLUCOSE, "SAMPLE_SOURCE_TYPE", dp)?.let { fields["SAMPLE_SOURCE_TYPE"] = if (it is Enum<*>) it.name else it.toString() }
+        return fields
     }
 
     private fun extractBloodPressureFields(dp: HealthDataPoint): Map<String, Any?> {
-        val f = mutableMapOf<String, Any?>()
-        getFieldValue<Float>(DataTypes.BLOOD_PRESSURE, "SYSTOLIC", dp)?.let { f["SYSTOLIC"] = it }
-        getFieldValue<Float>(DataTypes.BLOOD_PRESSURE, "DIASTOLIC", dp)?.let { f["DIASTOLIC"] = it }
-        getFieldValue<Float>(DataTypes.BLOOD_PRESSURE, "PULSE", dp)?.let { f["PULSE"] = it }
-        return f
+        val fields = mutableMapOf<String, Any?>()
+        getFieldValue<Float>(DataTypes.BLOOD_PRESSURE, "SYSTOLIC", dp)?.let { fields["SYSTOLIC"] = it }
+        getFieldValue<Float>(DataTypes.BLOOD_PRESSURE, "DIASTOLIC", dp)?.let { fields["DIASTOLIC"] = it }
+        getFieldValue<Float>(DataTypes.BLOOD_PRESSURE, "PULSE", dp)?.let { fields["PULSE"] = it }
+        return fields
     }
 
     private fun extractBodyTemperatureFields(dp: HealthDataPoint): Map<String, Any?> {
-        val f = mutableMapOf<String, Any?>()
-        getFieldValue<Float>(DataTypes.BODY_TEMPERATURE, "TEMPERATURE", dp)?.let { f["TEMPERATURE"] = it }
-        return f
+        val fields = mutableMapOf<String, Any?>()
+        getFieldValue<Float>(DataTypes.BODY_TEMPERATURE, "TEMPERATURE", dp)?.let { fields["TEMPERATURE"] = it }
+        return fields
     }
 
     private fun extractFloorsClimbedFields(dp: HealthDataPoint): Map<String, Any?> {
-        val f = mutableMapOf<String, Any?>()
-        getFieldValue<Int>(DataTypes.FLOORS_CLIMBED, "FLOORS", dp)?.let { f["FLOORS"] = it }
-        return f
+        val fields = mutableMapOf<String, Any?>()
+        getFieldValue<Int>(DataTypes.FLOORS_CLIMBED, "FLOORS", dp)?.let { fields["FLOORS"] = it }
+        return fields
     }
 
     private fun extractBodyCompositionFields(dp: HealthDataPoint): Map<String, Any?> {
-        val f = mutableMapOf<String, Any?>()
-        getFieldValue<Float>(DataTypes.BODY_COMPOSITION, "WEIGHT", dp)?.let { f["WEIGHT"] = it }
-        getFieldValue<Float>(DataTypes.BODY_COMPOSITION, "HEIGHT", dp)?.let { f["HEIGHT"] = it }
-        getFieldValue<Float>(DataTypes.BODY_COMPOSITION, "BODY_FAT", dp)?.let { f["BODY_FAT"] = it }
-        getFieldValue<Float>(DataTypes.BODY_COMPOSITION, "BODY_FAT_MASS", dp)?.let { f["BODY_FAT_MASS"] = it }
-        getFieldValue<Float>(DataTypes.BODY_COMPOSITION, "FAT_FREE_MASS", dp)?.let { f["FAT_FREE_MASS"] = it }
-        getFieldValue<Float>(DataTypes.BODY_COMPOSITION, "SKELETAL_MUSCLE_MASS", dp)?.let { f["SKELETAL_MUSCLE_MASS"] = it }
-        getFieldValue<Float>(DataTypes.BODY_COMPOSITION, "BMI", dp)?.let { f["BMI"] = it }
-        getFieldValue<Float>(DataTypes.BODY_COMPOSITION, "BASAL_METABOLIC_RATE", dp)?.let { f["BASAL_METABOLIC_RATE"] = it }
-        return f
+        val fields = mutableMapOf<String, Any?>()
+        getFieldValue<Float>(DataTypes.BODY_COMPOSITION, "WEIGHT", dp)?.let { fields["WEIGHT"] = it }
+        getFieldValue<Float>(DataTypes.BODY_COMPOSITION, "HEIGHT", dp)?.let { fields["HEIGHT"] = it }
+        getFieldValue<Float>(DataTypes.BODY_COMPOSITION, "BODY_FAT", dp)?.let { fields["BODY_FAT"] = it }
+        getFieldValue<Float>(DataTypes.BODY_COMPOSITION, "BODY_FAT_MASS", dp)?.let { fields["BODY_FAT_MASS"] = it }
+        getFieldValue<Float>(DataTypes.BODY_COMPOSITION, "FAT_FREE_MASS", dp)?.let { fields["FAT_FREE_MASS"] = it }
+        getFieldValue<Float>(DataTypes.BODY_COMPOSITION, "SKELETAL_MUSCLE_MASS", dp)?.let { fields["SKELETAL_MUSCLE_MASS"] = it }
+        getFieldValue<Float>(DataTypes.BODY_COMPOSITION, "BMI", dp)?.let { fields["BMI"] = it }
+        getFieldValue<Float>(DataTypes.BODY_COMPOSITION, "BASAL_METABOLIC_RATE", dp)?.let { fields["BASAL_METABOLIC_RATE"] = it }
+        return fields
     }
 
     private fun extractWaterIntakeFields(dp: HealthDataPoint): Map<String, Any?> {
-        val f = mutableMapOf<String, Any?>()
-        getFieldValue<Float>(DataTypes.WATER_INTAKE, "VOLUME", dp)?.let { f["VOLUME"] = it }
-        return f
+        val fields = mutableMapOf<String, Any?>()
+        getFieldValue<Float>(DataTypes.WATER_INTAKE, "VOLUME", dp)?.let { fields["VOLUME"] = it }
+        return fields
     }
 
     @Suppress("UNCHECKED_CAST")
     private fun extractExerciseFields(dp: HealthDataPoint): Map<String, Any?> {
-        val f = mutableMapOf<String, Any?>()
-        getFieldValue<Any>(DataTypes.EXERCISE, "EXERCISE_TYPE", dp)?.let { f["EXERCISE_TYPE"] = if (it is Enum<*>) it.name else it.toString() }
-        getFieldValue<Float>(DataTypes.EXERCISE, "TOTAL_CALORIES", dp)?.let { f["TOTAL_CALORIES"] = it }
-        getFieldValue<Long>(DataTypes.EXERCISE, "TOTAL_DURATION", dp)?.let { f["TOTAL_DURATION"] = it }
-        getFieldValue<String>(DataTypes.EXERCISE, "CUSTOM_TITLE", dp)?.let { f["CUSTOM_TITLE"] = it }
+        val fields = mutableMapOf<String, Any?>()
+        getFieldValue<Any>(DataTypes.EXERCISE, "EXERCISE_TYPE", dp)?.let { fields["EXERCISE_TYPE"] = if (it is Enum<*>) it.name else it.toString() }
+        getFieldValue<Float>(DataTypes.EXERCISE, "TOTAL_CALORIES", dp)?.let { fields["TOTAL_CALORIES"] = it }
+        getFieldValue<Long>(DataTypes.EXERCISE, "TOTAL_DURATION", dp)?.let { fields["TOTAL_DURATION"] = it }
+        getFieldValue<String>(DataTypes.EXERCISE, "CUSTOM_TITLE", dp)?.let { fields["CUSTOM_TITLE"] = it }
         getFieldValue<List<*>>(DataTypes.EXERCISE, "SESSIONS", dp)?.let { sessions ->
-            f["SESSIONS"] = sessions.mapNotNull { extractSession(it) }
+            fields["SESSIONS"] = sessions.mapNotNull { extractObjectFields(it) }
         }
-        return f
+        return fields
     }
 
-    private fun extractSession(session: Any?): Map<String, Any?>? {
-        if (session == null) return null
+    @Suppress("UNCHECKED_CAST")
+    private fun extractSleepFields(dp: HealthDataPoint): Map<String, Any?> {
+        val fields = mutableMapOf<String, Any?>()
+        getFieldValue<Any>(DataTypes.SLEEP, "STAGE", dp)?.let { fields["STAGE"] = if (it is Enum<*>) it.name else it.toString() }
+        getFieldValue<Float>(DataTypes.SLEEP, "EFFICIENCY", dp)?.let { fields["EFFICIENCY"] = it }
+        getFieldValue<Int>(DataTypes.SLEEP, "SLEEP_SCORE", dp)?.let { fields["SLEEP_SCORE"] = it }
+        getFieldValue<List<*>>(DataTypes.SLEEP, "SESSIONS", dp)?.let { sessions ->
+            fields["SESSIONS"] = sessions.mapNotNull { extractSleepSessionFields(it) }
+        }
+        return fields
+    }
+
+    /**
+     * Generic getter-based extraction for Samsung SDK objects.
+     * Consolidates the previously duplicated extractSession/extractSleepSession/extractSleepStage methods.
+     */
+    private fun extractObjectFields(obj: Any?): Map<String, Any?>? {
+        if (obj == null) return null
         val data = mutableMapOf<String, Any?>()
         try {
-            session.javaClass.methods
+            obj.javaClass.methods
                 .filter { it.parameterCount == 0 && it.name.startsWith("get") && it.name != "getClass" }
                 .forEach { method ->
                     try {
-                        val value = method.invoke(session) ?: return@forEach
+                        val value = method.invoke(obj) ?: return@forEach
                         val key = method.name.removePrefix("get").let { it.first().lowercase() + it.drop(1) }
                         when (value) {
                             is Number -> data[key] = value
@@ -1232,19 +1266,7 @@ class SamsungHealthManager(
         return data.ifEmpty { null }
     }
 
-    @Suppress("UNCHECKED_CAST")
-    private fun extractSleepFields(dp: HealthDataPoint): Map<String, Any?> {
-        val f = mutableMapOf<String, Any?>()
-        getFieldValue<Any>(DataTypes.SLEEP, "STAGE", dp)?.let { f["STAGE"] = if (it is Enum<*>) it.name else it.toString() }
-        getFieldValue<Float>(DataTypes.SLEEP, "EFFICIENCY", dp)?.let { f["EFFICIENCY"] = it }
-        getFieldValue<Int>(DataTypes.SLEEP, "SLEEP_SCORE", dp)?.let { f["SLEEP_SCORE"] = it }
-        getFieldValue<List<*>>(DataTypes.SLEEP, "SESSIONS", dp)?.let { sessions ->
-            f["SESSIONS"] = sessions.mapNotNull { extractSleepSession(it) }
-        }
-        return f
-    }
-
-    private fun extractSleepSession(session: Any?): Map<String, Any?>? {
+    private fun extractSleepSessionFields(session: Any?): Map<String, Any?>? {
         if (session == null) return null
         val data = mutableMapOf<String, Any?>()
         try {
@@ -1262,31 +1284,9 @@ class SamsungHealthManager(
                             is java.time.Instant -> data[key] = value.toEpochMilli()
                             is java.time.Duration -> data[key] = value.toMillis()
                             is List<*> -> {
-                                val stages = value.mapNotNull { extractSleepStage(it) }
+                                val stages = value.mapNotNull { extractObjectFields(it) }
                                 if (stages.isNotEmpty()) data[key] = stages
                             }
-                        }
-                    } catch (_: Exception) {}
-                }
-        } catch (_: Exception) {}
-        return data.ifEmpty { null }
-    }
-
-    private fun extractSleepStage(stage: Any?): Map<String, Any?>? {
-        if (stage == null) return null
-        val data = mutableMapOf<String, Any?>()
-        try {
-            stage.javaClass.methods
-                .filter { it.parameterCount == 0 && it.name.startsWith("get") && it.name != "getClass" }
-                .forEach { method ->
-                    try {
-                        val value = method.invoke(stage) ?: return@forEach
-                        val key = method.name.removePrefix("get").let { it.first().lowercase() + it.drop(1) }
-                        when (value) {
-                            is Number -> data[key] = value
-                            is Enum<*> -> data[key] = value.name
-                            is java.time.Instant -> data[key] = value.toEpochMilli()
-                            is java.time.Duration -> data[key] = value.toMillis()
                         }
                     } catch (_: Exception) {}
                 }
@@ -1303,33 +1303,3 @@ class SamsungHealthManager(
         } catch (_: Exception) { null }
     }
 }
-
-// ---------------------------------------------------------------------------
-// Internal raw data models (Samsung-specific, not exposed via interface)
-// ---------------------------------------------------------------------------
-
-data class HealthDataRecord(
-    val uid: String,
-    val dataType: String,
-    val startTime: Long,
-    val endTime: Long?,
-    val dataSource: RawDataSource,
-    val device: DeviceInfo,
-    val fields: Map<String, Any?>
-)
-
-data class RawDataSource(val appId: String?, val deviceId: String?)
-
-data class DeviceInfo(
-    val deviceId: String?,
-    val manufacturer: String,
-    val model: String,
-    val name: String,
-    val brand: String,
-    val product: String,
-    val osType: String,
-    val osVersion: String,
-    val sdkVersion: Int,
-    val deviceType: String?,
-    val isSourceDevice: Boolean = false
-)

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/SamsungModels.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/SamsungModels.kt
@@ -1,0 +1,32 @@
+package com.openwearables.health.sdk
+
+/**
+ * Internal raw data models used by [SamsungHealthManager].
+ * These are Samsung-specific and not exposed via the [HealthDataProvider] interface.
+ */
+
+data class HealthDataRecord(
+    val uid: String,
+    val dataType: String,
+    val startTime: Long,
+    val endTime: Long?,
+    val dataSource: RawDataSource,
+    val device: DeviceInfo,
+    val fields: Map<String, Any?>
+)
+
+data class RawDataSource(val appId: String?, val deviceId: String?)
+
+data class DeviceInfo(
+    val deviceId: String?,
+    val manufacturer: String,
+    val model: String,
+    val name: String,
+    val brand: String,
+    val product: String,
+    val osType: String,
+    val osVersion: String,
+    val sdkVersion: Int,
+    val deviceType: String?,
+    val isSourceDevice: Boolean = false
+)

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/SecureStorage.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/SecureStorage.kt
@@ -5,10 +5,15 @@ import android.content.SharedPreferences
 import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import java.security.KeyStore
 
 /**
  * Secure storage for credentials using EncryptedSharedPreferences.
  * Mirrors the iOS Keychain-based storage approach.
+ *
+ * If EncryptedSharedPreferences fails to initialize (e.g. corrupted KeyStore),
+ * the class attempts to clear corrupted keys and retry before throwing. It does
+ * NOT silently fall back to unencrypted storage.
  */
 class SecureStorage(private val context: Context) {
 
@@ -17,13 +22,11 @@ class SecureStorage(private val context: Context) {
         private const val PREFS_NAME = "com.openwearables.healthsdk.secure"
         private const val CONFIG_PREFS_NAME = "com.openwearables.healthsdk.config"
 
-        // Secure keys (encrypted)
         private const val KEY_ACCESS_TOKEN = "accessToken"
         private const val KEY_REFRESH_TOKEN = "refreshToken"
         private const val KEY_USER_ID = "userId"
         private const val KEY_API_KEY = "apiKey"
 
-        // Config keys (not encrypted, not sensitive)
         private const val KEY_HOST = "host"
         private const val KEY_CUSTOM_SYNC_URL = "customSyncUrl"
         private const val KEY_SYNC_ACTIVE = "syncActive"
@@ -32,22 +35,62 @@ class SecureStorage(private val context: Context) {
         private const val KEY_APP_INSTALLED = "appInstalled"
     }
 
+    /**
+     * Whether the encrypted storage initialized successfully.
+     * If false, credentials are NOT being stored securely.
+     */
+    var isEncryptionActive: Boolean = true
+        private set
+
     private val securePrefs: SharedPreferences by lazy {
         try {
-            val masterKey = MasterKey.Builder(context)
-                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                .build()
-
-            EncryptedSharedPreferences.create(
-                context,
-                PREFS_NAME,
-                masterKey,
-                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-            )
+            createEncryptedPrefs()
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to create encrypted prefs, falling back to regular prefs", e)
+            Log.e(TAG, "Failed to create encrypted prefs, attempting recovery", e)
+            try {
+                clearCorruptedKeyStoreEntry()
+                createEncryptedPrefs()
+            } catch (retryException: Exception) {
+                Log.e(TAG, "Recovery failed — encrypted storage unavailable. " +
+                    "Sensitive data will NOT be stored.", retryException)
+                isEncryptionActive = false
+                throw IllegalStateException(
+                    "EncryptedSharedPreferences initialization failed after recovery attempt. " +
+                    "This may be a device-level KeyStore issue.", retryException
+                )
+            }
+        }
+    }
+
+    private fun createEncryptedPrefs(): SharedPreferences {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+
+        return EncryptedSharedPreferences.create(
+            context,
+            PREFS_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+
+    private fun clearCorruptedKeyStoreEntry() {
+        try {
+            val keyStore = KeyStore.getInstance("AndroidKeyStore")
+            keyStore.load(null)
+            keyStore.deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+            Log.d(TAG, "Cleared corrupted KeyStore entry")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to clear KeyStore entry", e)
+        }
+        try {
             context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit().clear().apply()
+            Log.d(TAG, "Cleared corrupted shared prefs file")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to clear shared prefs file", e)
         }
     }
 
@@ -177,12 +220,7 @@ class SecureStorage(private val context: Context) {
 
     fun clearAll() {
         securePrefs.edit().clear().apply()
-        configPrefs.edit()
-            .remove(KEY_HOST)
-            .remove(KEY_CUSTOM_SYNC_URL)
-            .remove(KEY_SYNC_ACTIVE)
-            .remove(KEY_TRACKED_TYPES)
-            .remove(KEY_HEALTH_PROVIDER)
-            .apply()
+        configPrefs.edit().clear().apply()
+        configPrefs.edit().putBoolean(KEY_APP_INSTALLED, true).apply()
     }
 }

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/SyncManager.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/SyncManager.kt
@@ -3,9 +3,20 @@ package com.openwearables.health.sdk
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.work.*
-import com.google.gson.Gson
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -16,6 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
+@Serializable
 data class TypeSyncProgress(
     val typeIdentifier: String,
     var sentCount: Int = 0,
@@ -23,6 +35,7 @@ data class TypeSyncProgress(
     var pendingAnchorTimestamp: Long? = null
 )
 
+@Serializable
 data class SyncState(
     val userKey: String,
     val fullExport: Boolean,
@@ -48,33 +61,30 @@ class SyncManager(
     private val context: Context,
     private val secureStorage: SecureStorage,
     private val healthProvider: HealthDataProvider,
+    private val dispatchers: DispatcherProvider,
     private val logger: (String) -> Unit,
     private val onAuthError: ((Int, String) -> Unit)? = null
 ) {
     companion object {
         private const val TAG = "SyncManager"
-        private const val SYNC_PREFS_NAME = "com.openwearables.healthsdk.sync"
-        private const val KEY_ANCHORS = "anchors"
-        private const val WORK_NAME_PERIODIC = "health_sync_periodic"
-        private const val CHUNK_SIZE = 2000
-        private const val SYNC_INTERVAL_MINUTES = 5L
-        private const val SYNC_STATE_DIR = "health_sync_state"
-        private const val SYNC_STATE_FILE = "state.json"
-        const val SDK_VERSION = "0.2.0"
+
+        val sharedHttpClient: OkHttpClient by lazy {
+            OkHttpClient.Builder()
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(120, TimeUnit.SECONDS)
+                .writeTimeout(120, TimeUnit.SECONDS)
+                .build()
+        }
     }
 
     private val syncPrefs: SharedPreferences by lazy {
-        context.getSharedPreferences(SYNC_PREFS_NAME, Context.MODE_PRIVATE)
+        context.getSharedPreferences(StorageKeys.SYNC_PREFS_NAME, Context.MODE_PRIVATE)
     }
 
-    private val gson = Gson()
-    private val prettyGson = com.google.gson.GsonBuilder().setPrettyPrinting().create()
+    private val json = Json { ignoreUnknownKeys = true }
+    private val prettyJson = Json { prettyPrint = true; ignoreUnknownKeys = true }
 
-    private val httpClient = OkHttpClient.Builder()
-        .connectTimeout(30, TimeUnit.SECONDS)
-        .readTimeout(120, TimeUnit.SECONDS)
-        .writeTimeout(120, TimeUnit.SECONDS)
-        .build()
+    private val httpClient = sharedHttpClient
 
     private val dateFormatter: java.time.format.DateTimeFormatter =
         java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
@@ -83,6 +93,14 @@ class SyncManager(
     private val isSyncing = AtomicBoolean(false)
     private val tokenRefreshLock = ReentrantLock()
     private var isRefreshingToken = false
+
+    private val stateMutex = Mutex()
+    private var inMemoryState: SyncState? = null
+
+    var syncIntervalMinutes: Long = SyncDefaults.SYNC_INTERVAL_MINUTES
+        set(value) {
+            field = maxOf(value, SyncDefaults.MIN_SYNC_INTERVAL_MINUTES)
+        }
 
     // MARK: - User Key
 
@@ -121,32 +139,32 @@ class SyncManager(
     // MARK: - Background Sync
 
     suspend fun startBackgroundSync(host: String, customSyncUrl: String?): Boolean {
-        withContext(Dispatchers.Main) {
-            val constraints = Constraints.Builder()
-                .setRequiredNetworkType(NetworkType.CONNECTED)
-                .build()
-
-            scheduleNextSync(host, customSyncUrl, constraints)
-            logger("Scheduled sync every $SYNC_INTERVAL_MINUTES minute(s)")
-        }
-
+        schedulePeriodicSync(host, customSyncUrl)
         syncNow(host, customSyncUrl, fullExport = !hasCompletedInitialSync())
         return true
     }
 
-    private fun scheduleNextSync(host: String, customSyncUrl: String?, constraints: Constraints) {
-        val work = OneTimeWorkRequestBuilder<HealthSyncWorker>()
+    private fun schedulePeriodicSync(host: String, customSyncUrl: String?) {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+        val work = PeriodicWorkRequestBuilder<HealthSyncWorker>(
+            syncIntervalMinutes, TimeUnit.MINUTES
+        )
             .setConstraints(constraints)
-            .setInitialDelay(SYNC_INTERVAL_MINUTES, TimeUnit.MINUTES)
             .setInputData(workDataOf(
                 HealthSyncWorker.KEY_HOST to host,
                 HealthSyncWorker.KEY_CUSTOM_SYNC_URL to customSyncUrl
             ))
             .build()
 
-        WorkManager.getInstance(context).enqueueUniqueWork(
-            WORK_NAME_PERIODIC, ExistingWorkPolicy.REPLACE, work
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            SyncDefaults.WORK_NAME_PERIODIC,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            work
         )
+        logger("Scheduled periodic sync every $syncIntervalMinutes minute(s)")
     }
 
     fun scheduleExpeditedSync(host: String, customSyncUrl: String?) {
@@ -164,16 +182,14 @@ class SyncManager(
             .build()
 
         WorkManager.getInstance(context).enqueueUniqueWork(
-            "health_sync_expedited", ExistingWorkPolicy.REPLACE, expeditedWork
+            SyncDefaults.WORK_NAME_EXPEDITED, ExistingWorkPolicy.REPLACE, expeditedWork
         )
         logger("Scheduled expedited sync")
     }
 
     suspend fun stopBackgroundSync() {
-        withContext(Dispatchers.Main) {
-            WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME_PERIODIC)
-            logger("Cancelled periodic sync")
-        }
+        WorkManager.getInstance(context).cancelUniqueWork(SyncDefaults.WORK_NAME_PERIODIC)
+        logger("Cancelled periodic sync")
     }
 
     // MARK: - Sync Now
@@ -199,17 +215,24 @@ class SyncManager(
                 return
             }
 
-            val existingState = loadSyncState()
+            val existingState = stateMutex.withLock { loadSyncStateFromDisk() }
             val isResuming = existingState != null && existingState.hasProgress
 
             val startIndex: Int
             if (isResuming) {
                 logger("Sync: resuming (${existingState!!.totalSentCount} sent, ${existingState.completedTypes.size}/${trackedTypes.size} types done)")
-                startIndex = getResumeTypeIndex()
+                startIndex = existingState.currentTypeIndex
+                stateMutex.withLock { inMemoryState = existingState }
             } else {
                 val mode = if (fullExport) "full export" else "incremental"
                 logger("Sync: starting ($mode, ${trackedTypes.size} types, ${healthProvider.providerName})")
-                startNewSyncState(fullExport)
+                stateMutex.withLock {
+                    inMemoryState = SyncState(
+                        userKey = userKey(), fullExport = fullExport,
+                        createdAt = System.currentTimeMillis()
+                    )
+                    persistStateToDisk()
+                }
                 startIndex = 0
             }
 
@@ -227,24 +250,38 @@ class SyncManager(
     ) {
         for (i in startIndex until types.size) {
             val type = types[i]
-            if (!shouldSyncType(type)) {
+
+            val alreadySynced = stateMutex.withLock {
+                inMemoryState?.completedTypes?.contains(type) == true
+            }
+            if (alreadySynced) {
                 logger("Skipping $type - already synced")
                 continue
             }
 
-            updateCurrentTypeIndex(i)
+            stateMutex.withLock {
+                inMemoryState?.currentTypeIndex = i
+            }
+
             val success = processType(type, fullExport, endpoint)
             if (!success) {
                 logger("Sync paused at $type, will resume later")
+                stateMutex.withLock { persistStateToDisk() }
                 return
             }
         }
-        finalizeSyncState()
+
+        stateMutex.withLock {
+            val state = inMemoryState ?: return
+            if (state.fullExport) markFullExportDone()
+            logger("Sync: complete (${state.totalSentCount} items, ${state.completedTypes.size} types)")
+            clearSyncSessionInternal()
+        }
     }
 
     private suspend fun processType(type: String, fullExport: Boolean, endpoint: String): Boolean {
         if (fullExport) {
-            return processTypeNewestFirst(type, olderThan = null, endpoint = endpoint)
+            return processTypeNewestFirst(type, endpoint)
         }
 
         val anchors = loadAnchors()
@@ -252,11 +289,13 @@ class SyncManager(
 
         logger("  $type: querying...")
 
-        val result = healthProvider.readData(type, anchor, CHUNK_SIZE)
+        val result = healthProvider.readData(type, anchor, SyncDefaults.CHUNK_SIZE)
 
         if (result.data.isEmpty) {
             logger("  $type: no new data")
-            updateTypeProgress(type, 0, isComplete = true, anchorTimestamp = null)
+            stateMutex.withLock {
+                updateInMemoryProgress(type, 0, isComplete = true, anchorTimestamp = null)
+            }
             return true
         }
 
@@ -265,7 +304,10 @@ class SyncManager(
         val sendResult = sendPayload(endpoint, payload)
 
         if (sendResult.success) {
-            updateTypeProgress(type, count, isComplete = true, anchorTimestamp = result.maxTimestamp)
+            stateMutex.withLock {
+                updateInMemoryProgress(type, count, isComplete = true, anchorTimestamp = result.maxTimestamp)
+                persistStateToDisk()
+            }
             logger("  $type: $count items sent (${sendResult.payloadSizeKb} KB) -> ${sendResult.statusCode}")
             return true
         } else {
@@ -276,59 +318,80 @@ class SyncManager(
     }
 
     /**
-     * Full-export: fetch data newest-first in chunks, matching the iOS
-     * `processTypeNewestFirst` strategy. Each chunk moves further back in time
-     * using the oldest record's timestamp as the cursor.
+     * Full-export: fetch data newest-first in chunks. Uses a while loop
+     * instead of recursion to avoid continuation chain buildup on large datasets.
      */
     private suspend fun processTypeNewestFirst(
         type: String,
-        olderThan: Long?,
         endpoint: String
     ): Boolean {
-        logger("  $type: querying (newest first${olderThan?.let { ", olderThan=${java.time.Instant.ofEpochMilli(it)}" } ?: ""})...")
+        var olderThan: Long? = null
 
-        val result = healthProvider.readDataDescending(type, olderThan, CHUNK_SIZE)
+        while (true) {
+            logger("  $type: querying (newest first${olderThan?.let { ", olderThan=${java.time.Instant.ofEpochMilli(it)}" } ?: ""})...")
 
-        if (result.data.isEmpty) {
-            logger("  $type: all data sent (newest first)")
-            updateTypeProgress(type, 0, isComplete = true, anchorTimestamp = null)
-            return true
+            val result = healthProvider.readDataDescending(type, olderThan, SyncDefaults.CHUNK_SIZE)
+
+            if (result.data.isEmpty) {
+                logger("  $type: all data sent (newest first)")
+                stateMutex.withLock {
+                    updateInMemoryProgress(type, 0, isComplete = true, anchorTimestamp = null)
+                    persistStateToDisk()
+                }
+                return true
+            }
+
+            val count = result.data.totalCount
+            val payload = buildPayload(result.data)
+            val sendResult = sendPayload(endpoint, payload)
+
+            if (!sendResult.success) {
+                val reason = sendResult.statusCode?.let { "HTTP $it" } ?: "network error"
+                logger("  $type: $count items -> failed ($reason)")
+                return false
+            }
+
+            val anchorTs = if (olderThan == null) result.maxTimestamp else null
+            val isLastChunk = count < SyncDefaults.CHUNK_SIZE
+
+            logger("  $type: $count items sent (${sendResult.payloadSizeKb} KB) -> ${sendResult.statusCode}")
+
+            stateMutex.withLock {
+                updateInMemoryProgress(type, count, isComplete = isLastChunk, anchorTimestamp = anchorTs)
+                if (isLastChunk) persistStateToDisk()
+            }
+
+            if (isLastChunk) return true
+
+            olderThan = result.minTimestamp
         }
+    }
 
-        val count = result.data.totalCount
-        val payload = buildPayload(result.data)
-        val sendResult = sendPayload(endpoint, payload)
-
-        if (!sendResult.success) {
-            val reason = sendResult.statusCode?.let { "HTTP $it" } ?: "network error"
-            logger("  $type: $count items -> failed ($reason)")
-            return false
+    private fun updateInMemoryProgress(typeIdentifier: String, sentInChunk: Int, isComplete: Boolean, anchorTimestamp: Long?) {
+        val state = inMemoryState ?: return
+        val progress = state.typeProgress.getOrPut(typeIdentifier) { TypeSyncProgress(typeIdentifier) }
+        progress.sentCount += sentInChunk
+        progress.isComplete = isComplete
+        if (anchorTimestamp != null) progress.pendingAnchorTimestamp = anchorTimestamp
+        state.totalSentCount += sentInChunk
+        if (isComplete) {
+            state.completedTypes.add(typeIdentifier)
+            progress.pendingAnchorTimestamp?.let { saveAnchor(typeIdentifier, it) }
         }
-
-        // Only save the anchor from the first chunk (the newest data's max timestamp)
-        val anchorTs = if (olderThan == null) result.maxTimestamp else null
-        val isLastChunk = count < CHUNK_SIZE
-
-        logger("  $type: $count items sent (${sendResult.payloadSizeKb} KB) -> ${sendResult.statusCode}")
-        updateTypeProgress(type, count, isComplete = isLastChunk, anchorTimestamp = anchorTs)
-
-        if (isLastChunk) return true
-
-        return processTypeNewestFirst(type, result.minTimestamp, endpoint)
     }
 
     // MARK: - Payload (unified)
 
     private fun buildPayload(data: UnifiedHealthData): Map<String, Any> = mapOf(
         "provider" to healthProvider.providerId,
-        "sdkVersion" to SDK_VERSION,
+        "sdkVersion" to SyncDefaults.SDK_VERSION,
         "syncTimestamp" to UnifiedTimestamp.fromEpochMs(System.currentTimeMillis()),
         "data" to data.toDataMap()
     )
 
     // MARK: - Token Refresh
 
-    private suspend fun attemptTokenRefresh(): Boolean = withContext(Dispatchers.IO) {
+    private suspend fun attemptTokenRefresh(): Boolean = withContext(dispatchers.io) {
         tokenRefreshLock.withLock { isRefreshingToken = true }
         try {
             val refreshToken = secureStorage.getRefreshToken()
@@ -340,7 +403,8 @@ class SyncManager(
 
             android.util.Log.d(TAG, "Attempting token refresh...")
             val url = "$apiBaseUrl/token/refresh"
-            val body = gson.toJson(mapOf("refresh_token" to refreshToken))
+            val bodyMap = mapOf("refresh_token" to refreshToken)
+            val body = json.encodeToString(bodyMap)
             val request = Request.Builder()
                 .url(url)
                 .post(body.toRequestBody("application/json".toMediaType()))
@@ -352,11 +416,11 @@ class SyncManager(
             android.util.Log.d(TAG, "Token refresh response [${response.code}]: $responseBody")
 
             if (response.isSuccessful && responseBody != null) {
-                @Suppress("UNCHECKED_CAST")
-                val json = gson.fromJson(responseBody, Map::class.java) as? Map<String, Any>
-                val newAccessToken = json?.get("access_token") as? String
+                val jsonObj = json.parseToJsonElement(responseBody).jsonObject
+                val newAccessToken = jsonObj["access_token"]?.jsonPrimitive?.contentOrNull
                 if (newAccessToken != null) {
-                    secureStorage.updateTokens(newAccessToken, json["refresh_token"] as? String)
+                    val newRefreshToken = jsonObj["refresh_token"]?.jsonPrimitive?.contentOrNull
+                    secureStorage.updateTokens(newAccessToken, newRefreshToken)
                     logger("Token refreshed")
                     return@withContext true
                 }
@@ -376,12 +440,35 @@ class SyncManager(
 
     private data class SendResult(val success: Boolean, val statusCode: Int?, val payloadSizeKb: Int)
 
-    private suspend fun sendPayload(endpoint: String, payload: Map<String, Any>): SendResult =
-        withContext(Dispatchers.IO) {
+    private suspend fun sendPayload(endpoint: String, payload: Map<String, Any>): SendResult {
+        val jsonBody = serializePayload(payload)
+        return sendPayloadRaw(endpoint, jsonBody)
+    }
+
+    private fun serializePayload(payload: Map<String, Any>): String {
+        val element = mapToJsonElement(payload)
+        return json.encodeToString(JsonElement.serializer(), element)
+    }
+
+    private fun mapToJsonElement(value: Any?): JsonElement {
+        return when (value) {
+            null -> JsonNull
+            is Boolean -> JsonPrimitive(value)
+            is Number -> JsonPrimitive(value)
+            is String -> JsonPrimitive(value)
+            is Map<*, *> -> JsonObject(
+                value.entries.associate { (k, v) -> k.toString() to mapToJsonElement(v) }
+            )
+            is List<*> -> JsonArray(value.map { mapToJsonElement(it) })
+            else -> JsonPrimitive(value.toString())
+        }
+    }
+
+    private suspend fun sendPayloadRaw(endpoint: String, jsonBody: String): SendResult =
+        withContext(dispatchers.io) {
             try {
-                val jsonBody = gson.toJson(payload)
                 val sizeKb = jsonBody.length / 1024
-                android.util.Log.d(TAG, "REQUEST [$endpoint] (${sizeKb} KB):\n${prettyGson.toJson(payload)}")
+                android.util.Log.d(TAG, "REQUEST [$endpoint] (${sizeKb} KB)")
 
                 val requestBuilder = Request.Builder()
                     .url(endpoint)
@@ -458,23 +545,26 @@ class SyncManager(
     // MARK: - Anchors
 
     private fun loadAnchors(): Map<String, Long> {
-        val json = syncPrefs.getString(KEY_ANCHORS, null) ?: return emptyMap()
+        val jsonStr = syncPrefs.getString(StorageKeys.KEY_ANCHORS, null) ?: return emptyMap()
         return try {
-            @Suppress("UNCHECKED_CAST")
-            val map = gson.fromJson(json, Map::class.java) as? Map<String, Double>
-            map?.mapValues { it.value.toLong() } ?: emptyMap()
+            val map = json.decodeFromString<Map<String, Double>>(jsonStr)
+            map.mapValues { it.value.toLong() }
         } catch (_: Exception) { emptyMap() }
     }
 
     private fun saveAnchor(type: String, timestamp: Long) {
         val current = loadAnchors().toMutableMap()
         current[type] = timestamp
-        syncPrefs.edit().putString(KEY_ANCHORS, gson.toJson(current)).apply()
+        val element = mapToJsonElement(current)
+        syncPrefs.edit().putString(
+            StorageKeys.KEY_ANCHORS,
+            json.encodeToString(JsonElement.serializer(), element)
+        ).apply()
     }
 
     fun resetAnchors() {
         syncPrefs.edit()
-            .remove(KEY_ANCHORS)
+            .remove(StorageKeys.KEY_ANCHORS)
             .putBoolean(fullDoneKey(), false)
             .apply()
         clearSyncSession()
@@ -485,18 +575,19 @@ class SyncManager(
     private fun hasCompletedInitialSync(): Boolean = syncPrefs.getBoolean(fullDoneKey(), false)
     private fun markFullExportDone() { syncPrefs.edit().putBoolean(fullDoneKey(), true).apply() }
 
-    // MARK: - Sync State
+    // MARK: - Sync State (Mutex-protected disk I/O)
 
-    private fun syncStateDir(): File = File(context.filesDir, SYNC_STATE_DIR).also { if (!it.exists()) it.mkdirs() }
-    private fun syncStateFile(): File = File(syncStateDir(), SYNC_STATE_FILE)
+    private fun syncStateDir(): File = File(context.filesDir, StorageKeys.SYNC_STATE_DIR).also { if (!it.exists()) it.mkdirs() }
+    private fun syncStateFile(): File = File(syncStateDir(), StorageKeys.SYNC_STATE_FILE)
 
-    private fun saveSyncState(state: SyncState) {
+    private fun persistStateToDisk() {
+        val state = inMemoryState ?: return
         try {
-            val json = gson.toJson(state)
-            if (json.isNotBlank() && json.startsWith("{")) {
+            val jsonStr = json.encodeToString(state)
+            if (jsonStr.isNotBlank() && jsonStr.startsWith("{")) {
                 val file = syncStateFile()
                 val tempFile = File(file.parent, "${file.name}.tmp")
-                tempFile.writeText(json)
+                tempFile.writeText(jsonStr)
                 tempFile.renameTo(file)
             }
         } catch (e: Exception) {
@@ -504,14 +595,14 @@ class SyncManager(
         }
     }
 
-    private fun loadSyncState(): SyncState? {
+    private fun loadSyncStateFromDisk(): SyncState? {
         return try {
             val file = syncStateFile()
             if (!file.exists()) return null
-            val json = file.readText()
-            if (json.isBlank()) { file.delete(); return null }
-            val state = gson.fromJson(json, SyncState::class.java)
-            if (state == null || state.userKey != userKey()) { clearSyncSession(); return null }
+            val jsonStr = file.readText()
+            if (jsonStr.isBlank()) { file.delete(); return null }
+            val state = json.decodeFromString<SyncState>(jsonStr)
+            if (state.userKey != userKey()) { clearSyncSessionInternal(); return null }
             state
         } catch (e: Exception) {
             logger("Corrupted sync state, clearing: ${e.message}")
@@ -520,52 +611,13 @@ class SyncManager(
         }
     }
 
-    private fun startNewSyncState(fullExport: Boolean): SyncState {
-        val state = SyncState(
-            userKey = userKey(), fullExport = fullExport,
-            createdAt = System.currentTimeMillis()
-        )
-        saveSyncState(state)
-        return state
+    private fun clearSyncSessionInternal() {
+        inMemoryState = null
+        try { syncStateFile().delete() } catch (_: Exception) {}
     }
-
-    private fun updateTypeProgress(typeIdentifier: String, sentInChunk: Int, isComplete: Boolean, anchorTimestamp: Long?) {
-        val state = loadSyncState() ?: return
-        var progress = state.typeProgress[typeIdentifier] ?: TypeSyncProgress(typeIdentifier)
-        progress.sentCount += sentInChunk
-        progress.isComplete = isComplete
-        if (anchorTimestamp != null) progress.pendingAnchorTimestamp = anchorTimestamp
-        state.typeProgress[typeIdentifier] = progress
-        state.totalSentCount += sentInChunk
-        if (isComplete) {
-            state.completedTypes.add(typeIdentifier)
-            progress.pendingAnchorTimestamp?.let { saveAnchor(typeIdentifier, it) }
-        }
-        saveSyncState(state)
-    }
-
-    private fun updateCurrentTypeIndex(index: Int) {
-        val state = loadSyncState() ?: return
-        state.currentTypeIndex = index
-        saveSyncState(state)
-    }
-
-    private fun finalizeSyncState() {
-        val state = loadSyncState() ?: return
-        if (state.fullExport) markFullExportDone()
-        logger("Sync: complete (${state.totalSentCount} items, ${state.completedTypes.size} types)")
-        clearSyncSession()
-    }
-
-    private fun shouldSyncType(typeIdentifier: String): Boolean {
-        val state = loadSyncState() ?: return true
-        return !state.completedTypes.contains(typeIdentifier)
-    }
-
-    private fun getResumeTypeIndex(): Int = loadSyncState()?.currentTypeIndex ?: 0
 
     fun getSyncStatus(): Map<String, Any?> {
-        val state = loadSyncState()
+        val state = inMemoryState ?: loadSyncStateFromDisk()
         return if (state != null) {
             mapOf(
                 "hasResumableSession" to state.hasProgress,
@@ -585,118 +637,12 @@ class SyncManager(
         }
     }
 
-    fun hasResumableSyncSession(): Boolean = loadSyncState()?.hasProgress == true
+    fun hasResumableSyncSession(): Boolean {
+        return (inMemoryState ?: loadSyncStateFromDisk())?.hasProgress == true
+    }
 
     fun clearSyncSession() {
-        try {
-            syncStateFile().delete()
-            logger("Cleared sync state")
-        } catch (e: Exception) {
-            logger("Failed to clear sync state: ${e.message}")
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// WorkManager worker
-// ---------------------------------------------------------------------------
-
-class HealthSyncWorker(
-    context: Context,
-    params: WorkerParameters
-) : CoroutineWorker(context, params) {
-
-    companion object {
-        const val KEY_HOST = "host"
-        const val KEY_CUSTOM_SYNC_URL = "customSyncUrl"
-        private const val NOTIFICATION_ID = 9001
-        private const val CHANNEL_ID = "health_sync_channel"
-        private const val WORK_NAME_PERIODIC = "health_sync_periodic"
-        private const val SYNC_INTERVAL_MINUTES = 5L
-    }
-
-    override suspend fun doWork(): Result {
-        val host = inputData.getString(KEY_HOST) ?: return Result.failure()
-        val customSyncUrl = inputData.getString(KEY_CUSTOM_SYNC_URL)
-
-        try {
-            setForeground(getForegroundInfo())
-            android.util.Log.d("HealthSyncWorker", "Running as foreground service")
-        } catch (e: Exception) {
-            android.util.Log.w("HealthSyncWorker", "Could not promote to foreground: ${e.message}")
-        }
-
-        val secureStorage = SecureStorage(applicationContext)
-        val provider = createProvider(applicationContext, secureStorage)
-        val syncManager = SyncManager(applicationContext, secureStorage, provider, {
-            android.util.Log.d("HealthSyncWorker", it)
-        })
-
-        return try {
-            val trackedTypes = secureStorage.getTrackedTypes()
-            provider.setTrackedTypes(trackedTypes)
-
-            android.util.Log.d("HealthSyncWorker", "Background sync (provider: ${provider.providerId})")
-            syncManager.syncNow(host, customSyncUrl, fullExport = false)
-
-            scheduleNextSync(host, customSyncUrl)
-            Result.success()
-        } catch (e: Exception) {
-            android.util.Log.e("HealthSyncWorker", "Sync failed", e)
-            scheduleNextSync(host, customSyncUrl)
-            Result.retry()
-        }
-    }
-
-    private fun createProvider(context: Context, storage: SecureStorage): HealthDataProvider {
-        val providerId = storage.getProvider()
-        val log: (String) -> Unit = { android.util.Log.d("HealthSyncWorker", it) }
-        return when (providerId) {
-            "google" -> HealthConnectManager(context, null, log)
-            else -> SamsungHealthManager(context, null, log)
-        }
-    }
-
-    private fun scheduleNextSync(host: String, customSyncUrl: String?) {
-        val constraints = Constraints.Builder()
-            .setRequiredNetworkType(NetworkType.CONNECTED)
-            .build()
-        val nextWork = OneTimeWorkRequestBuilder<HealthSyncWorker>()
-            .setConstraints(constraints)
-            .setInitialDelay(SYNC_INTERVAL_MINUTES, TimeUnit.MINUTES)
-            .setInputData(workDataOf(
-                KEY_HOST to host,
-                KEY_CUSTOM_SYNC_URL to customSyncUrl
-            ))
-            .build()
-        WorkManager.getInstance(applicationContext).enqueueUniqueWork(
-            WORK_NAME_PERIODIC, ExistingWorkPolicy.REPLACE, nextWork
-        )
-    }
-
-    override suspend fun getForegroundInfo(): ForegroundInfo {
-        createNotificationChannel()
-        val notification = androidx.core.app.NotificationCompat.Builder(applicationContext, CHANNEL_ID)
-            .setContentTitle("Health Sync")
-            .setContentText("Syncing health data...")
-            .setSmallIcon(android.R.drawable.ic_popup_sync)
-            .setPriority(androidx.core.app.NotificationCompat.PRIORITY_LOW)
-            .setOngoing(true)
-            .build()
-        return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
-            ForegroundInfo(NOTIFICATION_ID, notification, android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
-        } else {
-            ForegroundInfo(NOTIFICATION_ID, notification)
-        }
-    }
-
-    private fun createNotificationChannel() {
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-            val channel = android.app.NotificationChannel(
-                CHANNEL_ID, "Health Sync", android.app.NotificationManager.IMPORTANCE_LOW
-            ).apply { description = "Background health data synchronization" }
-            (applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager)
-                .createNotificationChannel(channel)
-        }
+        clearSyncSessionInternal()
+        logger("Cleared sync state")
     }
 }


### PR DESCRIPTION
## Summary

Comprehensive refactoring of the Android SDK.

### Critical fixes
- **Activity memory leaks** — all three Activity-holding classes (SDK, SamsungHealthManager, HealthConnectManager) now use `WeakReference<Activity>` instead of strong references
- **Sync chain breakage** — replaced `OneTimeWorkRequest` daisy-chain with `PeriodicWorkRequest` (15 min default). Previously, if the OS killed the process before `scheduleNextSync()` ran, background sync would stop forever
- **Thread-safe sync state** — added `Mutex` around `state.json` reads/writes to prevent race conditions between foreground `syncNow` and background `HealthSyncWorker`
- **`destroy()` singleton reset** — calling `destroy()` now properly resets the singleton so `initialize()` works correctly afterwards
- **SecureStorage silent fallback** — no longer silently falls back to unencrypted `SharedPreferences` when `EncryptedSharedPreferences` fails. Attempts KeyStore recovery, then throws

### Architecture improvements
- **Gson → kotlinx-serialization** — removed Gson dependency, migrated to Kotlin-native JSON serialization
- **DispatcherProvider abstraction** — no more hardcoded `Dispatchers.IO`/`Dispatchers.Main`, enabling unit testing with `TestDispatcher`
- **Constructor injection** — managers accept dependencies via constructor, enabling mock injection for tests
- **`Outcome<T>` sealed class** — explicit error handling replacing silent `catch → false` patterns
- **Configurable sync interval** — `setSyncInterval(minutes)` API, minimum 15 min (Android `PeriodicWorkRequest` limit)
- **Shared `OkHttpClient`** — singleton in `SyncManager.companion` instead of new instance every worker run

### Code organization
- Extracted `HealthSyncWorker` from `SyncManager.kt` into own file
- Extracted `HealthDataRecord`, `RawDataSource`, `DeviceInfo` into `SamsungModels.kt`
- Extracted magic values into `Constants.kt` (`ProviderIds`, `SyncDefaults`, `StorageKeys`, `NotificationConfig`)
- Deduplicated `readData`/`readDataDescending` in `HealthConnectManager` into single `readRecordsInternal()`
- Consolidated 3 nearly-identical reflection crawlers into reusable `extractObjectFields()`
- Renamed cryptic variable names (`f` → `fields`)

### Manifest
- Added Samsung Health package visibility query (`com.samsung.android.app.shealth`) for Android 11+
- Documented `READ_HEALTH_DATA_IN_BACKGROUND` restricted permission requirements

### Breaking changes
- SDK version bumped to `0.4.0`
- `SamsungHealthManager` and `HealthConnectManager` constructors now require `DispatcherProvider` parameter
- `SyncManager` constructor now requires `DispatcherProvider` parameter
- `SecureStorage` throws on encrypted prefs init failure instead of silent fallback
- Default sync interval changed from 5 min to 15 min
