### PR TITLE
Sync range

### DIFF
--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -80,7 +80,7 @@ afterEvaluate {
                 from(components["release"])
                 groupId = "com.openwearables.health"
                 artifactId = "sdk"
-                version = "0.4.0"
+                version = "0.5.0"
 
                 pom {
                     name.set("Open Wearables Health SDK")

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/Constants.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/Constants.kt
@@ -16,7 +16,7 @@ object SyncDefaults {
     const val CHUNK_SIZE = 2000
     const val WORK_NAME_PERIODIC = "health_sync_periodic"
     const val WORK_NAME_EXPEDITED = "health_sync_expedited"
-    const val SDK_VERSION = "0.4.0"
+    const val SDK_VERSION = "0.5.0"
 }
 
 object StorageKeys {

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/OpenWearablesHealthSDK.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/OpenWearablesHealthSDK.kt
@@ -7,6 +7,15 @@ import kotlinx.coroutines.*
 import java.lang.ref.WeakReference
 
 /**
+ * Controls which log messages the SDK emits.
+ *
+ * - [NONE]:   No logs at all.
+ * - [ALWAYS]: Logs are always emitted (Logcat + listener).
+ * - [DEBUG]:  Logs are emitted only in debug builds (the default).
+ */
+enum class OWLogLevel { NONE, ALWAYS, DEBUG }
+
+/**
  * Main entry point for the Open Wearables Health SDK.
  *
  * Provides a unified API for reading health data from Samsung Health and
@@ -69,6 +78,9 @@ class OpenWearablesHealthSDK private constructor(
     // Listeners
     var logListener: ((String) -> Unit)? = null
     var authErrorListener: ((statusCode: Int, message: String) -> Unit)? = null
+
+    /// Current log level. Default is DEBUG (logs only in debuggable builds).
+    var logLevel: OWLogLevel = OWLogLevel.DEBUG
 
     // Components
     internal val secureStorage: SecureStorage by lazy { SecureStorage(context) }
@@ -239,9 +251,20 @@ class OpenWearablesHealthSDK private constructor(
     // Sync
     // -----------------------------------------------------------------------
 
-    suspend fun startBackgroundSync() {
+    /**
+     * Start background health data synchronization.
+     *
+     * @param syncDaysBack How many days back to sync. Syncs from the start of the day
+     *   that many days ago (inclusive). When `null` (the default), syncs all available history.
+     */
+    suspend fun startBackgroundSync(syncDaysBack: Int? = null) {
         val h = host ?: throw IllegalStateException("Not configured")
         if (!secureStorage.hasSession()) throw IllegalStateException("Not signed in")
+
+        if (syncDaysBack != null) {
+            secureStorage.saveSyncDaysBack(syncDaysBack)
+            logMessage("Sync days back set to $syncDaysBack")
+        }
 
         secureStorage.setSyncActive(true)
         logMessage("Background sync started (${getOrCreateProvider().providerName})")
@@ -415,6 +438,14 @@ class OpenWearablesHealthSDK private constructor(
     }
 
     internal fun logMessage(message: String) {
+        when (logLevel) {
+            OWLogLevel.NONE -> return
+            OWLogLevel.ALWAYS -> { /* proceed */ }
+            OWLogLevel.DEBUG -> {
+                val isDebuggable = (context.applicationInfo.flags and android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) != 0
+                if (!isDebuggable) return
+            }
+        }
         Log.d(TAG, message)
         logListener?.invoke(message)
     }

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/SecureStorage.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/SecureStorage.kt
@@ -33,6 +33,7 @@ class SecureStorage(private val context: Context) {
         private const val KEY_TRACKED_TYPES = "trackedTypes"
         private const val KEY_HEALTH_PROVIDER = "healthProvider"
         private const val KEY_APP_INSTALLED = "appInstalled"
+        private const val KEY_SYNC_DAYS_BACK = "syncDaysBack"
     }
 
     /**
@@ -198,6 +199,15 @@ class SecureStorage(private val context: Context) {
     fun getTrackedTypes(): List<String> {
         return configPrefs.getStringSet(KEY_TRACKED_TYPES, emptySet())?.toList() ?: emptyList()
     }
+
+    // MARK: - Sync Days Back
+
+    fun saveSyncDaysBack(days: Int) {
+        configPrefs.edit().putInt(KEY_SYNC_DAYS_BACK, days).apply()
+    }
+
+    /** Returns stored sync days back, or 0 if not set (meaning full sync / no limit). */
+    fun getSyncDaysBack(): Int = configPrefs.getInt(KEY_SYNC_DAYS_BACK, 0)
 
     // MARK: - Health Provider
 

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/SyncManager.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/SyncManager.kt
@@ -102,6 +102,25 @@ class SyncManager(
             field = maxOf(value, SyncDefaults.MIN_SYNC_INTERVAL_MINUTES)
         }
 
+    // MARK: - Sync Start Timestamp
+
+    /**
+     * Computes the earliest epoch-ms timestamp to sync from, based on persisted `syncDaysBack`.
+     * Returns the start of the day (midnight local time) that many days ago,
+     * or `null` if full sync (no limit) is configured.
+     */
+    private fun syncStartTimestamp(): Long? {
+        val daysBack = secureStorage.getSyncDaysBack()
+        if (daysBack <= 0) return null
+        val cal = java.util.Calendar.getInstance()
+        cal.set(java.util.Calendar.HOUR_OF_DAY, 0)
+        cal.set(java.util.Calendar.MINUTE, 0)
+        cal.set(java.util.Calendar.SECOND, 0)
+        cal.set(java.util.Calendar.MILLISECOND, 0)
+        cal.add(java.util.Calendar.DAY_OF_YEAR, -daysBack)
+        return cal.timeInMillis
+    }
+
     // MARK: - User Key
 
     private fun userKey(): String {
@@ -218,14 +237,17 @@ class SyncManager(
             val existingState = stateMutex.withLock { loadSyncStateFromDisk() }
             val isResuming = existingState != null && existingState.hasProgress
 
+            val floor = syncStartTimestamp()
+            val floorLabel = if (floor != null) "since ${java.time.Instant.ofEpochMilli(floor)}" else "full history"
+
             val startIndex: Int
             if (isResuming) {
-                logger("Sync: resuming (${existingState!!.totalSentCount} sent, ${existingState.completedTypes.size}/${trackedTypes.size} types done)")
+                logger("Sync: resuming (${existingState!!.totalSentCount} sent, ${existingState.completedTypes.size}/${trackedTypes.size} types done, $floorLabel)")
                 startIndex = existingState.currentTypeIndex
                 stateMutex.withLock { inMemoryState = existingState }
             } else {
                 val mode = if (fullExport) "full export" else "incremental"
-                logger("Sync: starting ($mode, ${trackedTypes.size} types, ${healthProvider.providerName})")
+                logger("Sync: starting ($mode, ${trackedTypes.size} types, ${healthProvider.providerName}, $floorLabel)")
                 stateMutex.withLock {
                     inMemoryState = SyncState(
                         userKey = userKey(), fullExport = fullExport,
@@ -285,7 +307,13 @@ class SyncManager(
         }
 
         val anchors = loadAnchors()
-        val anchor = anchors[type]
+        val storedAnchor = anchors[type]
+        val floor = syncStartTimestamp()
+        val anchor = when {
+            storedAnchor != null && floor != null -> maxOf(storedAnchor, floor)
+            storedAnchor != null -> storedAnchor
+            else -> floor
+        }
 
         logger("  $type: querying...")
 
@@ -301,6 +329,7 @@ class SyncManager(
 
         val count = result.data.totalCount
         val payload = buildPayload(result.data)
+        logPayloadSummary(result.data)
         val sendResult = sendPayload(endpoint, payload)
 
         if (sendResult.success) {
@@ -326,6 +355,8 @@ class SyncManager(
         endpoint: String
     ): Boolean {
         var olderThan: Long? = null
+        val floor = syncStartTimestamp()
+        val floorIso = floor?.let { UnifiedTimestamp.fromEpochMs(it) }
 
         while (true) {
             logger("  $type: querying (newest first${olderThan?.let { ", olderThan=${java.time.Instant.ofEpochMilli(it)}" } ?: ""})...")
@@ -341,8 +372,23 @@ class SyncManager(
                 return true
             }
 
-            val count = result.data.totalCount
-            val payload = buildPayload(result.data)
+            val reachedFloor = floor != null && result.minTimestamp != null && result.minTimestamp <= floor
+            val isLastChunk = result.data.totalCount < SyncDefaults.CHUNK_SIZE || reachedFloor
+
+            val data = if (reachedFloor && floorIso != null) result.data.filterSince(floorIso) else result.data
+
+            if (data.isEmpty) {
+                logger("  $type: all data within range sent")
+                stateMutex.withLock {
+                    updateInMemoryProgress(type, 0, isComplete = true, anchorTimestamp = null)
+                    persistStateToDisk()
+                }
+                return true
+            }
+
+            val count = data.totalCount
+            val payload = buildPayload(data)
+            logPayloadSummary(data)
             val sendResult = sendPayload(endpoint, payload)
 
             if (!sendResult.success) {
@@ -352,9 +398,8 @@ class SyncManager(
             }
 
             val anchorTs = if (olderThan == null) result.maxTimestamp else null
-            val isLastChunk = count < SyncDefaults.CHUNK_SIZE
 
-            logger("  $type: $count items sent (${sendResult.payloadSizeKb} KB) -> ${sendResult.statusCode}")
+            logger("  $type: $count items sent (${sendResult.payloadSizeKb} KB) -> ${sendResult.statusCode}${if (reachedFloor) " [reached sync boundary]" else ""}")
 
             stateMutex.withLock {
                 updateInMemoryProgress(type, count, isComplete = isLastChunk, anchorTimestamp = anchorTs)
@@ -388,6 +433,82 @@ class SyncManager(
         "syncTimestamp" to UnifiedTimestamp.fromEpochMs(System.currentTimeMillis()),
         "data" to data.toDataMap()
     )
+
+    // MARK: - Payload Summary Logging
+
+    private val valueSumTypes = setOf(
+        "steps", "active_calories_burned", "basal_calories_burned",
+        "distance", "floors_climbed",
+        "StepCount", "ActiveEnergyBurned", "BasalEnergyBurned",
+        "DistanceWalkingRunning", "FlightsClimbed",
+    )
+
+    private fun logPayloadSummary(data: UnifiedHealthData) {
+        val stats = mutableMapOf<String, PayloadTypeStats>()
+
+        for (r in data.records) {
+            val s = stats.getOrPut(r.type) { PayloadTypeStats() }
+            s.count++
+            s.updateDateRange(r.startDate)
+            if (r.type in valueSumTypes) {
+                s.unit = r.unit
+                val dayKey = r.startDate.take(10)
+                s.dailyValues[dayKey] = (s.dailyValues[dayKey] ?: 0.0) + r.value
+            }
+        }
+        for (sl in data.sleep) {
+            val s = stats.getOrPut("sleep") { PayloadTypeStats() }
+            s.count++
+            s.updateDateRange(sl.startDate)
+        }
+        for (w in data.workouts) {
+            val key = "workout/${w.type}"
+            val s = stats.getOrPut(key) { PayloadTypeStats() }
+            s.count++
+            s.updateDateRange(w.startDate)
+        }
+
+        val totalCount = stats.values.sumOf { it.count }
+        logger("Sending $totalCount items:")
+
+        for ((type, ts) in stats.entries.sortedByDescending { it.value.count }) {
+            val range = if (ts.minDate != null && ts.maxDate != null) {
+                "${ts.minDate!!.take(16).replace('T', ' ')} → ${ts.maxDate!!.take(16).replace('T', ' ')}"
+            } else "no dates"
+
+            if (ts.dailyValues.isEmpty()) {
+                logger("  ✅ $type: ${ts.count} ($range)")
+            } else {
+                val total = ts.dailyValues.values.sum()
+                val unit = ts.unit ?: ""
+                logger("  ✅ $type: ${ts.count} samples, ${formatNumber(total)} $unit total ($range)")
+                for (day in ts.dailyValues.keys.sorted()) {
+                    logger("     $day: ${formatNumber(ts.dailyValues[day]!!)} $unit")
+                }
+            }
+        }
+    }
+
+    private class PayloadTypeStats(
+        var count: Int = 0,
+        var minDate: String? = null,
+        var maxDate: String? = null,
+        var unit: String? = null,
+        val dailyValues: MutableMap<String, Double> = mutableMapOf()
+    ) {
+        fun updateDateRange(date: String) {
+            if (minDate == null || date < minDate!!) minDate = date
+            if (maxDate == null || date > maxDate!!) maxDate = date
+        }
+    }
+
+    private fun formatNumber(value: Double): String {
+        return if (value == value.toLong().toDouble()) {
+            "%,d".format(value.toLong())
+        } else {
+            "%.1f".format(value)
+        }
+    }
 
     // MARK: - Token Refresh
 

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/UnifiedPayload.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/UnifiedPayload.kt
@@ -153,6 +153,16 @@ data class UnifiedHealthData(
         "workouts" to workouts.map { it.toMap() },
         "sleep" to sleep.map { it.toMap() }
     )
+
+    /**
+     * Returns a copy with only records/workouts/sleep whose startDate >= [floorIso].
+     * The ISO string comparison works because dates are in ISO-8601 format (lexicographic order).
+     */
+    fun filterSince(floorIso: String): UnifiedHealthData = UnifiedHealthData(
+        records = records.filter { it.startDate >= floorIso },
+        workouts = workouts.filter { it.startDate >= floorIso },
+        sleep = sleep.filter { it.startDate >= floorIso },
+    )
 }
 
 data class ProviderReadResult(


### PR DESCRIPTION
## Add syncDaysBack, log level control, payload summary logging, fix date filtering

- Optional `syncDaysBack` parameter on `startBackgroundSync` — limits sync to N days back (full day inclusive). `null` = full history (default).
- `OWLogLevel` enum (`NONE`, `ALWAYS`, `DEBUG`) with debug-only logging by default.
- Payload summary logging (per-type count, date range, daily step/calorie breakdown).
- Fixed full export not filtering records older than `syncDaysBack` when all data fits in a single chunk.