### PR TITLE
fix: OOM on large datasets, combined payloads, token refresh, notification API, clean logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 0.7.0
+
+* **Combined payloads**: all health data types are now merged into a single payload per sync round instead of separate requests per type.
+* **Interleaved sync**: data is fetched round-robin across all types (newest to oldest) instead of sequentially type-by-type.
+* **Streaming JSON serialization**: replaced in-memory `JsonElement` tree with `android.util.JsonWriter` streaming directly to OkHttp `RequestBody`, fixing `OutOfMemoryError` on large datasets.
+* **Bearer prefix normalization**: access tokens returned by the refresh endpoint without the `Bearer ` prefix are now handled correctly.
+* **Sign-out reliability**: `EncryptedSharedPreferences.clear()` replaced with individual key removal using `.commit()` to work around a known Android bug where `clear()` may not reliably remove all encrypted entries.
+* **`setSyncNotification()`**: customize the foreground notification title and text shown during background sync via WorkManager.
+* **Cleaned up logging**: removed verbose Samsung Health SDK reflection logs, per-record debug output, and all token/credential values from log output. Logs now show only essential sync lifecycle events, payload summaries, and HTTP statuses.
+
+## 0.6.0
+
+* Initial tracked release.

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -80,7 +80,7 @@ afterEvaluate {
                 from(components["release"])
                 groupId = "com.openwearables.health"
                 artifactId = "sdk"
-                version = "0.6.0"
+                version = "0.7.0"
 
                 pom {
                     name.set("Open Wearables Health SDK")

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/Constants.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/Constants.kt
@@ -16,7 +16,7 @@ object SyncDefaults {
     const val CHUNK_SIZE = 2000
     const val WORK_NAME_PERIODIC = "health_sync_periodic"
     const val WORK_NAME_EXPEDITED = "health_sync_expedited"
-    const val SDK_VERSION = "0.6.0"
+    const val SDK_VERSION = "0.7.0"
 }
 
 object StorageKeys {
@@ -31,4 +31,5 @@ object NotificationConfig {
     const val CHANNEL_ID = "health_sync_channel"
     const val CHANNEL_NAME = "Health Sync"
     const val CHANNEL_DESCRIPTION = "Background health data synchronization"
+    const val DEFAULT_TEXT = "Syncing health data..."
 }

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/HealthConnectManager.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/HealthConnectManager.kt
@@ -796,7 +796,6 @@ class HealthConnectManager(
                 TimeRangeFilter.before(Instant.now())
         }
 
-        logger("Reading sleep sessions (since: $sinceTimestamp, ascending: $ascending)")
         val response = client.readRecords(
             ReadRecordsRequest(
                 recordType = SleepSessionRecord::class,
@@ -805,7 +804,6 @@ class HealthConnectManager(
                 pageSize = limit
             )
         )
-        logger("Sleep query returned ${response.records.size} sessions")
         if (response.records.isEmpty()) return ProviderReadResult(UnifiedHealthData(), null)
 
         var maxTs: Long? = null
@@ -853,7 +851,6 @@ class HealthConnectManager(
             response.records.last().endTime.toEpochMilli()
         } else null
 
-        logger("Total sleep entries: ${sleepEntries.size}")
         return ProviderReadResult(UnifiedHealthData(sleep = sleepEntries), maxTs, minTs)
     }
 

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/HealthSyncWorker.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/HealthSyncWorker.kt
@@ -25,7 +25,6 @@ class HealthSyncWorker(
 
         try {
             setForeground(getForegroundInfo())
-            android.util.Log.d("HealthSyncWorker", "Running as foreground service")
         } catch (e: Exception) {
             android.util.Log.w("HealthSyncWorker", "Could not promote to foreground: ${e.message}")
         }
@@ -67,9 +66,10 @@ class HealthSyncWorker(
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
         createNotificationChannel()
+        val secureStorage = SecureStorage(applicationContext)
         val notification = androidx.core.app.NotificationCompat.Builder(applicationContext, NotificationConfig.CHANNEL_ID)
-            .setContentTitle(NotificationConfig.CHANNEL_NAME)
-            .setContentText("Syncing health data...")
+            .setContentTitle(secureStorage.getNotificationTitle())
+            .setContentText(secureStorage.getNotificationText())
             .setSmallIcon(android.R.drawable.ic_popup_sync)
             .setPriority(androidx.core.app.NotificationCompat.PRIORITY_LOW)
             .setOngoing(true)

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/OpenWearablesHealthSDK.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/OpenWearablesHealthSDK.kt
@@ -163,6 +163,18 @@ class OpenWearablesHealthSDK private constructor(
         logMessage("Sync interval set to ${maxOf(minutes, SyncDefaults.MIN_SYNC_INTERVAL_MINUTES)} minutes")
     }
 
+    /**
+     * Customize the foreground notification shown during background sync.
+     *
+     * @param title Notification title (default: "Health Sync")
+     * @param text  Notification body text (default: "Syncing health data...")
+     */
+    fun setSyncNotification(title: String? = null, text: String? = null) {
+        title?.let { secureStorage.saveNotificationTitle(it) }
+        text?.let { secureStorage.saveNotificationText(it) }
+        logMessage("Sync notification updated: title=${title ?: "(unchanged)"}, text=${text ?: "(unchanged)"}")
+    }
+
     private suspend fun autoRestoreSync() {
         val h = host
         if (h == null || secureStorage.getUserId() == null || !secureStorage.hasAuth) {

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/SamsungHealthManager.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/SamsungHealthManager.kt
@@ -205,22 +205,15 @@ class SamsungHealthManager(
         }
 
         try {
-            logger("[$typeId] Building read request (sinceTimestamp=$sinceTimestamp, limit=$limit, dataType=${dataType.javaClass.simpleName})")
             val request = buildReadRequest(dataType, sinceTimestamp, limit)
             if (request == null) {
-                logger("[$typeId] buildReadRequest returned null — reflection failed")
+                logger("[$typeId] Failed to build read request")
                 return@withContext emptyList()
             }
             val response = store.readData(request)
-            logger("[$typeId] Raw SDK response: ${response.dataList.size} data points")
             val records = response.dataList.mapNotNull { dp ->
-                val parsed = parseDataPoint(typeId, dp as HealthDataPoint)
-                if (parsed == null) {
-                    logger("[$typeId] parseDataPoint returned null for uid=${dp.uid}")
-                }
-                parsed
+                parseDataPoint(typeId, dp as HealthDataPoint)
             }
-            logger("[$typeId] After parsing: ${records.size} records (dropped ${response.dataList.size - records.size})")
             records
         } catch (e: Exception) {
             logger("[$typeId] Failed to read: ${e.javaClass.simpleName}: ${e.message}")
@@ -251,18 +244,15 @@ class SamsungHealthManager(
         }
 
         try {
-            logger("[$typeId] Building descending read request (olderThan=$olderThanTimestamp, limit=$limit)")
             val request = buildReadRequestDescending(dataType, olderThanTimestamp, limit)
             if (request == null) {
-                logger("[$typeId] buildReadRequestDescending returned null")
+                logger("[$typeId] Failed to build descending read request")
                 return@withContext emptyList()
             }
             val response = store.readData(request)
-            logger("[$typeId] Raw SDK response (desc): ${response.dataList.size} data points")
             val records = response.dataList.mapNotNull { dp ->
                 parseDataPoint(typeId, dp as HealthDataPoint)
             }
-            logger("[$typeId] After parsing (desc): ${records.size} records")
             records
         } catch (e: Exception) {
             logger("[$typeId] Failed to read (desc): ${e.javaClass.simpleName}: ${e.message}")
@@ -302,22 +292,12 @@ class SamsungHealthManager(
                 logger("[$typeId] Could not find aggregate operation '${config.aggregateOpName}'")
                 return emptyList()
             }
-            logger("[$typeId] Got aggregate op: ${aggregateOp.javaClass.name}")
 
             val builderGetter = aggregateOp.javaClass.methods.find {
                 it.name == "getRequestBuilder" || it.name == "requestBuilder"
-            }
-            if (builderGetter == null) {
-                logger("[$typeId] No requestBuilder on aggregate op. Methods: ${aggregateOp.javaClass.methods.map { it.name }}")
-                return emptyList()
-            }
-            val builder = builderGetter.invoke(aggregateOp)
-            if (builder == null) {
-                logger("[$typeId] requestBuilder returned null")
-                return emptyList()
-            }
+            } ?: return emptyList()
+            val builder = builderGetter.invoke(aggregateOp) ?: return emptyList()
             val builderClass = builder.javaClass
-            logger("[$typeId] Got builder: ${builderClass.name}")
 
             val startTime = if (sinceTimestamp != null) {
                 LocalDateTime.ofInstant(Instant.ofEpochMilli(sinceTimestamp + 1), ZoneId.systemDefault())
@@ -338,20 +318,14 @@ class SamsungHealthManager(
                     builderClass.getMethod("setLocalTimeFilterWithGroup", LocalTimeFilter::class.java, groupClass)
                         .invoke(builder, timeFilter, timeGroup)
                     hasGrouping = true
-                    logger("[$typeId] Applied hourly time grouping")
                 }
-            } catch (e: Exception) {
-                logger("[$typeId] Hourly grouping failed: ${e.javaClass.simpleName}: ${e.message}")
-            }
+            } catch (_: Exception) {}
 
             if (!hasGrouping) {
                 try {
                     builderClass.getMethod("setLocalTimeFilter", LocalTimeFilter::class.java)
                         .invoke(builder, timeFilter)
-                    logger("[$typeId] Applied simple time filter")
-                } catch (e: Exception) {
-                    logger("[$typeId] setLocalTimeFilter failed: ${e.message}")
-                }
+                } catch (_: Exception) {}
             }
 
             try {
@@ -359,11 +333,8 @@ class SamsungHealthManager(
             } catch (_: Exception) {}
 
             val request = builderClass.getMethod("build").invoke(builder) as AggregateRequest<Any>
-            logger("[$typeId] Built aggregate request: ${request.javaClass.name}")
-
             val response = store.aggregateData(request)
             val dataList = response.dataList
-            logger("[$typeId] Aggregate response: ${dataList.size} items")
 
             return dataList.mapNotNull { item -> parseAggregateItem(typeId, config.fieldName, item as Any) }
         } catch (e: Exception) {
@@ -431,7 +402,6 @@ class SamsungHealthManager(
             val request = builderClass.getMethod("build").invoke(builder) as AggregateRequest<Any>
             val response = store.aggregateData(request)
             val dataList = response.dataList
-            logger("[$typeId] Aggregate response (desc): ${dataList.size} items")
 
             return dataList.mapNotNull { item -> parseAggregateItem(typeId, config.fieldName, item as Any) }
         } catch (e: Exception) {
@@ -447,44 +417,26 @@ class SamsungHealthManager(
             val getter = companion.javaClass.methods.find { it.name == "get$opName" }
             if (getter != null) {
                 val op = getter.invoke(companion)
-                if (op != null) {
-                    logger("[$typeId] Got $opName via Companion.get$opName()")
-                    return op
-                }
+                if (op != null) return op
             }
-        } catch (e: Exception) {
-            logger("[$typeId] Companion.$opName failed: ${e.message}")
-        }
+        } catch (_: Exception) {}
 
         try {
             val field = dataType.javaClass.getField(opName)
             val op = field.get(dataType)
-            if (op != null) {
-                logger("[$typeId] Got $opName via static field")
-                return op
-            }
-        } catch (e: Exception) {
-            logger("[$typeId] Static field $opName failed: ${e.message}")
-        }
+            if (op != null) return op
+        } catch (_: Exception) {}
 
         try {
             val allOps = dataType.javaClass.getMethod("getAllAggregateOperations").invoke(dataType)
             if (allOps is Collection<*> && allOps.isNotEmpty()) {
-                logger("[$typeId] Found ${allOps.size} aggregate operations")
                 for (op in allOps) {
                     val name = try { op?.javaClass?.getMethod("getName")?.invoke(op)?.toString() } catch (_: Exception) { null }
-                    logger("[$typeId]   op: ${op?.javaClass?.simpleName}, name=$name")
-                    if (name != null && name.equals(opName, ignoreCase = true)) {
-                        logger("[$typeId] Matched op by name: $name")
-                        return op
-                    }
+                    if (name != null && name.equals(opName, ignoreCase = true)) return op
                 }
-                logger("[$typeId] No name match, using first op")
                 return allOps.first()
             }
-        } catch (e: Exception) {
-            logger("[$typeId] getAllAggregateOperations failed: ${e.message}")
-        }
+        } catch (_: Exception) {}
 
         return null
     }
@@ -516,7 +468,6 @@ class SamsungHealthManager(
                 else -> null
             }
 
-            logger("[$typeId] Aggregate item: startMs=$startMs, endMs=$endMs, value=$numericValue (type=${value?.javaClass?.simpleName})")
             if (startMs == null || numericValue == null || numericValue == 0.0) return null
 
             return HealthDataRecord(
@@ -536,7 +487,6 @@ class SamsungHealthManager(
             )
         } catch (e: Exception) {
             logger("[$typeId] Failed to parse aggregate item: ${e.javaClass.simpleName}: ${e.message}")
-            logger("[$typeId] Item class: ${item.javaClass.name}, methods: ${item.javaClass.methods.map { it.name }}")
             return null
         }
     }
@@ -585,9 +535,7 @@ class SamsungHealthManager(
                 listOf(UnifiedRecord(raw.uid, "HEART_RATE", startDate, endDate, zoneOffset, source, hr, "bpm", null, null))
             }
             "steps" -> {
-                val totalRaw = raw.fields["TOTAL"]
-                val total = (totalRaw as? Number)?.toDouble()
-                logger("[steps] convertRecords: uid=${raw.uid}, TOTAL raw=$totalRaw (type=${totalRaw?.javaClass?.simpleName}), converted=$total, allFields=${raw.fields}")
+                val total = (raw.fields["TOTAL"] as? Number)?.toDouble()
                 if (total == null) return null
                 listOf(UnifiedRecord(raw.uid, "STEP_COUNT", startDate, endDate, zoneOffset, source, total, "count", null, null))
             }
@@ -802,11 +750,8 @@ class SamsungHealthManager(
         val sleepScore = raw.fields["SLEEP_SCORE"] as? Number
         val scoreValues = sleepScore?.let { listOf(mapOf("type" to "sleepScore", "value" to it, "unit" to "score")) }
 
-        logger("Sleep record ${raw.uid}: fields=${raw.fields.keys}")
-
         val sessions = raw.fields["SESSIONS"] as? List<Map<String, Any?>> ?: emptyList()
         if (sessions.isEmpty()) {
-            logger("Sleep record ${raw.uid}: no sessions, using top-level STAGE")
             val stage = (raw.fields["STAGE"]?.toString() ?: "UNKNOWN").let { mapSamsungSleepStage(it) }
             return listOf(UnifiedSleep(
                 id = raw.uid,
@@ -821,13 +766,10 @@ class SamsungHealthManager(
             ))
         }
 
-        logger("Sleep record ${raw.uid}: ${sessions.size} sessions")
         val results = mutableListOf<UnifiedSleep>()
         for ((sIdx, session) in sessions.withIndex()) {
-            logger("  Session $sIdx keys: ${session.keys}")
             val stages = (session["sleepStages"] ?: session["stages"]) as? List<Map<String, Any?>>
             if (stages == null) {
-                logger("  Session $sIdx: no stages found, creating single entry")
                 val sessStart = (session["startTime"] as? Number)?.toLong() ?: raw.startTime
                 val sessEnd = (session["endTime"] as? Number)?.toLong() ?: raw.endTime ?: raw.startTime
                 results.add(UnifiedSleep(
@@ -843,7 +785,6 @@ class SamsungHealthManager(
                 ))
                 continue
             }
-            logger("  Session $sIdx: ${stages.size} stages")
             for ((stIdx, stageMap) in stages.withIndex()) {
                 val stageName = mapSamsungSleepStage(stageMap["stage"]?.toString() ?: "UNKNOWN")
                 val stStart = (stageMap["startTime"] as? Number)?.toLong()
@@ -931,24 +872,21 @@ class SamsungHealthManager(
         val builder = getRequestBuilder(dataType, limit) ?: return null
         val builderClass = builder.javaClass
 
-        try { builderClass.getMethod("setLimit", Int::class.java).invoke(builder, limit) } catch (e: Exception) { logger("[buildReadRequest] setLimit failed: ${e.message}") }
-        try { builderClass.getMethod("setOrdering", Ordering::class.java).invoke(builder, Ordering.ASC) } catch (e: Exception) { logger("[buildReadRequest] setOrdering failed: ${e.message}") }
+        try { builderClass.getMethod("setLimit", Int::class.java).invoke(builder, limit) } catch (_: Exception) {}
+        try { builderClass.getMethod("setOrdering", Ordering::class.java).invoke(builder, Ordering.ASC) } catch (_: Exception) {}
 
         if (sinceTimestamp != null) {
             try {
                 val startTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(sinceTimestamp + 1), ZoneId.systemDefault())
                 val filter = LocalTimeFilter.since(startTime)
                 builderClass.getMethod("setLocalTimeFilter", LocalTimeFilter::class.java).invoke(builder, filter)
-                logger("[buildReadRequest] Applied time filter since=$startTime")
-            } catch (e: Exception) { logger("[buildReadRequest] setLocalTimeFilter failed: ${e.message}") }
+            } catch (_: Exception) {}
         }
 
         return try {
-            val result = builderClass.getMethod("build").invoke(builder) as? ReadDataRequest<HealthDataPoint>
-            logger("[buildReadRequest] Result: ${if (result != null) "OK" else "null (cast failed)"}")
-            result
+            builderClass.getMethod("build").invoke(builder) as? ReadDataRequest<HealthDataPoint>
         } catch (e: Exception) {
-            logger("[buildReadRequest] build FAILED: ${e.javaClass.simpleName}: ${e.message}")
+            logger("Failed to build read request for ${dataType.javaClass.simpleName}: ${e.message}")
             null
         }
     }
@@ -967,14 +905,13 @@ class SamsungHealthManager(
                 val farPast = LocalDateTime.of(2000, 1, 1, 0, 0)
                 val filter = LocalTimeFilter.of(farPast, endTime)
                 builderClass.getMethod("setLocalTimeFilter", LocalTimeFilter::class.java).invoke(builder, filter)
-                logger("[buildReadRequestDescending] Applied time filter before=$endTime")
-            } catch (e: Exception) { logger("[buildReadRequestDescending] setLocalTimeFilter failed: ${e.message}") }
+            } catch (_: Exception) {}
         }
 
         return try {
             builderClass.getMethod("build").invoke(builder) as? ReadDataRequest<HealthDataPoint>
         } catch (e: Exception) {
-            logger("[buildReadRequestDescending] build FAILED: ${e.javaClass.simpleName}: ${e.message}")
+            logger("Failed to build descending read request: ${e.message}")
             null
         }
     }
@@ -983,15 +920,9 @@ class SamsungHealthManager(
         try {
             val builderMethod = dataType.javaClass.getMethod("getReadDataRequestBuilder")
             val builder = builderMethod.invoke(dataType)
-            if (builder != null) {
-                logger("[buildReadRequest] Got builder via dataType.getReadDataRequestBuilder()")
-                return builder
-            }
+            if (builder != null) return builder
         } catch (_: NoSuchMethodException) {
-            logger("[buildReadRequest] No getReadDataRequestBuilder on ${dataType.javaClass.simpleName}, trying ReadDataRequest.Builder()")
-        } catch (e: Exception) {
-            logger("[buildReadRequest] getReadDataRequestBuilder failed: ${e.message}, trying ReadDataRequest.Builder()")
-        }
+        } catch (_: Exception) {}
 
         return try {
             val rdClass = ReadDataRequest::class.java
@@ -999,22 +930,12 @@ class SamsungHealthManager(
                 .filter { !it.isInterface && it.simpleName != "Companion" }
                 .distinctBy { it.simpleName }
 
-            for (bc in builderClasses) {
-                for (c in bc.constructors) {
-                    logger("[buildReadRequest] ${bc.simpleName} constructor: (${c.parameterTypes.map { it.simpleName }.joinToString(", ")})")
-                }
-                for (m in bc.declaredMethods) {
-                    logger("[buildReadRequest] ${bc.simpleName}.${m.name}(${m.parameterTypes.map { it.simpleName }.joinToString(", ")}) -> ${m.returnType.simpleName}")
-                }
-            }
-
             val localDateBuilder = builderClasses.find { it.simpleName == "LocalDateBuilder" }
             if (localDateBuilder != null) {
                 val constructor = localDateBuilder.constructors.firstOrNull()
                 if (constructor != null) {
                     constructor.isAccessible = true
                     val paramTypes = constructor.parameterTypes
-                    logger("[buildReadRequest] Trying LocalDateBuilder with ${paramTypes.size} params: ${paramTypes.map { it.simpleName }}")
                     val args = paramTypes.map { pType ->
                         when {
                             DataType::class.java.isAssignableFrom(pType) -> dataType
@@ -1023,17 +944,14 @@ class SamsungHealthManager(
                             else -> null
                         }
                     }.toTypedArray()
-                    logger("[buildReadRequest] Constructed args: ${args.map { it?.javaClass?.simpleName ?: "null" }}")
-                    val builder = constructor.newInstance(*args)
-                    logger("[buildReadRequest] Got builder via LocalDateBuilder")
-                    return builder
+                    return constructor.newInstance(*args)
                 }
             }
 
-            logger("[buildReadRequest] Could not create any builder for ${dataType.javaClass.simpleName}")
+            logger("Could not create request builder for ${dataType.javaClass.simpleName}")
             null
         } catch (e: Exception) {
-            logger("[buildReadRequest] Fallback FAILED: ${e.javaClass.simpleName}: ${e.message}")
+            logger("Failed to create request builder: ${e.javaClass.simpleName}: ${e.message}")
             null
         }
     }
@@ -1151,11 +1069,9 @@ class SamsungHealthManager(
         val fields = mutableMapOf<String, Any?>()
         val totalLong = getFieldValue<Long>(DataTypes.STEPS, "TOTAL", dp)
         val totalAny = getFieldValue<Any>(DataTypes.STEPS, "TOTAL", dp)
-        logger("[steps] extractStepsFields: TOTAL as Long=$totalLong, Any=$totalAny (type=${totalAny?.javaClass?.simpleName})")
         if (totalLong != null) {
             fields["TOTAL"] = totalLong
         } else if (totalAny is Number) {
-            logger("[steps] TOTAL fallback via Number: ${totalAny.toLong()}")
             fields["TOTAL"] = totalAny.toLong()
         }
         return fields

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/SecureStorage.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/SecureStorage.kt
@@ -34,6 +34,8 @@ class SecureStorage(private val context: Context) {
         private const val KEY_HEALTH_PROVIDER = "healthProvider"
         private const val KEY_APP_INSTALLED = "appInstalled"
         private const val KEY_SYNC_DAYS_BACK = "syncDaysBack"
+        private const val KEY_NOTIFICATION_TITLE = "notificationTitle"
+        private const val KEY_NOTIFICATION_TEXT = "notificationText"
     }
 
     /**
@@ -193,11 +195,28 @@ class SecureStorage(private val context: Context) {
     // MARK: - Tracked Types
 
     fun saveTrackedTypes(types: List<String>) {
-        configPrefs.edit().putStringSet(KEY_TRACKED_TYPES, types.toSet()).apply()
+        val json = org.json.JSONArray(types).toString()
+        configPrefs.edit()
+            .remove(KEY_TRACKED_TYPES)
+            .putString(KEY_TRACKED_TYPES, json)
+            .apply()
     }
 
     fun getTrackedTypes(): List<String> {
-        return configPrefs.getStringSet(KEY_TRACKED_TYPES, emptySet())?.toList() ?: emptyList()
+        try {
+            val jsonStr = configPrefs.getString(KEY_TRACKED_TYPES, null)
+            if (jsonStr != null && jsonStr.startsWith("[")) {
+                val arr = org.json.JSONArray(jsonStr)
+                return (0 until arr.length()).map { arr.getString(it) }
+            }
+        } catch (_: ClassCastException) {
+            // Legacy StringSet format - fall through
+        } catch (_: Exception) { }
+        return try {
+            configPrefs.getStringSet(KEY_TRACKED_TYPES, emptySet())?.sorted() ?: emptyList()
+        } catch (_: Exception) {
+            emptyList()
+        }
     }
 
     // MARK: - Sync Days Back
@@ -217,6 +236,22 @@ class SecureStorage(private val context: Context) {
 
     fun getProvider(): String? = configPrefs.getString(KEY_HEALTH_PROVIDER, null)
 
+    // MARK: - Notification
+
+    fun saveNotificationTitle(title: String) {
+        configPrefs.edit().putString(KEY_NOTIFICATION_TITLE, title).apply()
+    }
+
+    fun saveNotificationText(text: String) {
+        configPrefs.edit().putString(KEY_NOTIFICATION_TEXT, text).apply()
+    }
+
+    fun getNotificationTitle(): String = configPrefs.getString(KEY_NOTIFICATION_TITLE, null)
+        ?: NotificationConfig.CHANNEL_NAME
+
+    fun getNotificationText(): String = configPrefs.getString(KEY_NOTIFICATION_TEXT, null)
+        ?: NotificationConfig.DEFAULT_TEXT
+
     // MARK: - API Base URL (derived from host)
 
     val apiBaseUrl: String?
@@ -229,8 +264,17 @@ class SecureStorage(private val context: Context) {
     // MARK: - Clear
 
     fun clearAll() {
-        securePrefs.edit().clear().apply()
-        configPrefs.edit().clear().apply()
-        configPrefs.edit().putBoolean(KEY_APP_INSTALLED, true).apply()
+        // Remove credential keys individually — EncryptedSharedPreferences.clear()
+        // has a known Android bug where it can leave orphan encrypted entries,
+        // causing hasSession() to return stale data after sign-out.
+        securePrefs.edit()
+            .remove(KEY_ACCESS_TOKEN)
+            .remove(KEY_REFRESH_TOKEN)
+            .remove(KEY_USER_ID)
+            .remove(KEY_API_KEY)
+            .commit()
+
+        configPrefs.edit().clear().commit()
+        configPrefs.edit().putBoolean(KEY_APP_INSTALLED, true).commit()
     }
 }

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/SyncManager.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/SyncManager.kt
@@ -9,17 +9,13 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -32,7 +28,8 @@ data class TypeSyncProgress(
     val typeIdentifier: String,
     var sentCount: Int = 0,
     var isComplete: Boolean = false,
-    var pendingAnchorTimestamp: Long? = null
+    var pendingAnchorTimestamp: Long? = null,
+    var pendingOlderThan: Long? = null
 )
 
 @Serializable
@@ -66,8 +63,6 @@ class SyncManager(
     private val onAuthError: ((Int, String) -> Unit)? = null
 ) {
     companion object {
-        private const val TAG = "SyncManager"
-
         val sharedHttpClient: OkHttpClient by lazy {
             OkHttpClient.Builder()
                 .connectTimeout(30, TimeUnit.SECONDS)
@@ -82,7 +77,6 @@ class SyncManager(
     }
 
     private val json = Json { ignoreUnknownKeys = true }
-    private val prettyJson = Json { prettyPrint = true; ignoreUnknownKeys = true }
 
     private val httpClient = sharedHttpClient
 
@@ -130,11 +124,14 @@ class SyncManager(
 
     // MARK: - Auth
 
+    private fun bearerValue(token: String): String =
+        if (token.startsWith("Bearer ")) token else "Bearer $token"
+
     private fun applyAuth(requestBuilder: Request.Builder) {
         val accessToken = secureStorage.getAccessToken()
         val apiKey = secureStorage.getApiKey()
         if (accessToken != null) {
-            requestBuilder.header("Authorization", accessToken)
+            requestBuilder.header("Authorization", bearerValue(accessToken))
         } else if (apiKey != null) {
             requestBuilder.header("X-Open-Wearables-API-Key", apiKey)
         }
@@ -144,7 +141,7 @@ class SyncManager(
         if (secureStorage.isApiKeyAuth) {
             requestBuilder.header("X-Open-Wearables-API-Key", credential)
         } else {
-            requestBuilder.header("Authorization", credential)
+            requestBuilder.header("Authorization", bearerValue(credential))
         }
     }
 
@@ -159,7 +156,7 @@ class SyncManager(
 
     suspend fun startBackgroundSync(host: String, customSyncUrl: String?): Boolean {
         schedulePeriodicSync(host, customSyncUrl)
-        syncNow(host, customSyncUrl, fullExport = !hasCompletedInitialSync())
+        scheduleExpeditedSync(host, customSyncUrl)
         return true
     }
 
@@ -240,10 +237,8 @@ class SyncManager(
             val floor = syncStartTimestamp()
             val floorLabel = if (floor != null) "since ${java.time.Instant.ofEpochMilli(floor)}" else "full history"
 
-            val startIndex: Int
             if (isResuming) {
                 logger("Sync: resuming (${existingState!!.totalSentCount} sent, ${existingState.completedTypes.size}/${trackedTypes.size} types done, $floorLabel)")
-                startIndex = existingState.currentTypeIndex
                 stateMutex.withLock { inMemoryState = existingState }
             } else {
                 val mode = if (fullExport) "full export" else "incremental"
@@ -255,41 +250,120 @@ class SyncManager(
                     )
                     persistStateToDisk()
                 }
-                startIndex = 0
             }
 
-            processTypes(trackedTypes, startIndex, fullExport, endpoint)
+            processTypesRoundRobin(trackedTypes, fullExport, endpoint)
         } finally {
             isSyncing.set(false)
         }
     }
 
-    private suspend fun processTypes(
+    // MARK: - Round-Robin Sync Orchestration (combined payloads)
+
+    private data class FetchResult(
+        val type: String,
+        val data: UnifiedHealthData = UnifiedHealthData(),
+        val count: Int = 0,
+        val nextCursor: Long? = null,
+        val anchorTimestamp: Long? = null,
+        val isDone: Boolean = false
+    )
+
+    private suspend fun processTypesRoundRobin(
         types: List<String>,
-        startIndex: Int,
         fullExport: Boolean,
         endpoint: String
     ) {
-        for (i in startIndex until types.size) {
-            val type = types[i]
+        val olderThanCursors = mutableMapOf<String, Long?>()
+        val anchorCursors = mutableMapOf<String, Long?>()
+        val completedTypes = mutableSetOf<String>()
 
-            val alreadySynced = stateMutex.withLock {
-                inMemoryState?.completedTypes?.contains(type) == true
+        stateMutex.withLock {
+            val state = inMemoryState
+            if (state != null) {
+                completedTypes.addAll(state.completedTypes)
+                for ((id, progress) in state.typeProgress) {
+                    if (!progress.isComplete) {
+                        progress.pendingOlderThan?.let { olderThanCursors[id] = it }
+                        progress.pendingAnchorTimestamp?.let { anchorCursors[id] = it }
+                    }
+                }
             }
-            if (alreadySynced) {
-                logger("Skipping $type - already synced")
-                continue
+        }
+
+        if (!fullExport) {
+            val anchors = loadAnchors()
+            val floor = syncStartTimestamp()
+            for (type in types) {
+                if (!completedTypes.contains(type) && !anchorCursors.containsKey(type)) {
+                    val storedAnchor = anchors[type]
+                    val anchor = when {
+                        storedAnchor != null && floor != null -> maxOf(storedAnchor, floor)
+                        storedAnchor != null -> storedAnchor
+                        else -> floor
+                    }
+                    anchorCursors[type] = anchor
+                }
+            }
+        }
+
+        while (true) {
+            val incompleteTypes = types.filter { !completedTypes.contains(it) }
+            if (incompleteTypes.isEmpty()) break
+
+            val perTypeLimit = maxOf(1, SyncDefaults.CHUNK_SIZE / incompleteTypes.size)
+
+            // Phase 1: Fetch one chunk from each type (no network yet)
+            val roundResults = mutableListOf<FetchResult>()
+
+            for (type in incompleteTypes) {
+                val result = if (fullExport) {
+                    fetchOneChunkNewestFirst(type, olderThanCursors[type], perTypeLimit)
+                } else {
+                    fetchOneChunkIncremental(type, anchorCursors[type], perTypeLimit)
+                }
+
+                roundResults.add(result)
+
+                if (result.isDone) {
+                    completedTypes.add(type)
+                } else {
+                    if (fullExport) olderThanCursors[type] = result.nextCursor
+                    else anchorCursors[type] = result.nextCursor
+                }
             }
 
+            // Phase 2: Merge all fetched data into one combined payload
+            val mergedData = UnifiedHealthData(
+                records = roundResults.flatMap { it.data.records },
+                workouts = roundResults.flatMap { it.data.workouts },
+                sleep = roundResults.flatMap { it.data.sleep }
+            )
+
+            if (!mergedData.isEmpty) {
+                val payload = buildPayload(mergedData)
+                logPayloadSummary(mergedData)
+                val sendResult = sendPayload(endpoint, payload)
+
+                if (!sendResult.success) {
+                    val reason = sendResult.statusCode?.let { "HTTP $it" } ?: "network error"
+                    logger("Combined round failed ($reason)")
+                    stateMutex.withLock { persistStateToDisk() }
+                    return
+                }
+
+                logger("Round sent: ${mergedData.totalCount} items (${sendResult.payloadSizeKb} KB) -> ${sendResult.statusCode}")
+            }
+
+            // Phase 3: Update progress for all types in this round
             stateMutex.withLock {
-                inMemoryState?.currentTypeIndex = i
-            }
-
-            val success = processType(type, fullExport, endpoint)
-            if (!success) {
-                logger("Sync paused at $type, will resume later")
-                stateMutex.withLock { persistStateToDisk() }
-                return
+                for (result in roundResults) {
+                    updateInMemoryProgress(result.type, result.count, isComplete = result.isDone, anchorTimestamp = result.anchorTimestamp)
+                    if (fullExport && !result.isDone) {
+                        inMemoryState?.typeProgress?.get(result.type)?.pendingOlderThan = result.nextCursor
+                    }
+                }
+                persistStateToDisk()
             }
         }
 
@@ -301,115 +375,70 @@ class SyncManager(
         }
     }
 
-    private suspend fun processType(type: String, fullExport: Boolean, endpoint: String): Boolean {
-        if (fullExport) {
-            return processTypeNewestFirst(type, endpoint)
-        }
+    // MARK: - Fetch-Only Chunk Processors (no network)
 
-        val anchors = loadAnchors()
-        val storedAnchor = anchors[type]
-        val floor = syncStartTimestamp()
-        val anchor = when {
-            storedAnchor != null && floor != null -> maxOf(storedAnchor, floor)
-            storedAnchor != null -> storedAnchor
-            else -> floor
-        }
-
-        logger("  $type: querying...")
-
-        val result = healthProvider.readData(type, anchor, SyncDefaults.CHUNK_SIZE)
-
-        if (result.data.isEmpty) {
-            logger("  $type: no new data")
-            stateMutex.withLock {
-                updateInMemoryProgress(type, 0, isComplete = true, anchorTimestamp = null)
-            }
-            return true
-        }
-
-        val count = result.data.totalCount
-        val payload = buildPayload(result.data)
-        logPayloadSummary(result.data)
-        val sendResult = sendPayload(endpoint, payload)
-
-        if (sendResult.success) {
-            stateMutex.withLock {
-                updateInMemoryProgress(type, count, isComplete = true, anchorTimestamp = result.maxTimestamp)
-                persistStateToDisk()
-            }
-            logger("  $type: $count items sent (${sendResult.payloadSizeKb} KB) -> ${sendResult.statusCode}")
-            return true
-        } else {
-            val reason = sendResult.statusCode?.let { "HTTP $it" } ?: "network error"
-            logger("  $type: $count items -> failed ($reason)")
-            return false
-        }
-    }
-
-    /**
-     * Full-export: fetch data newest-first in chunks. Uses a while loop
-     * instead of recursion to avoid continuation chain buildup on large datasets.
-     */
-    private suspend fun processTypeNewestFirst(
+    private suspend fun fetchOneChunkNewestFirst(
         type: String,
-        endpoint: String
-    ): Boolean {
-        var olderThan: Long? = null
+        olderThan: Long?,
+        limit: Int
+    ): FetchResult {
         val floor = syncStartTimestamp()
         val floorIso = floor?.let { UnifiedTimestamp.fromEpochMs(it) }
 
-        while (true) {
-            logger("  $type: querying (newest first${olderThan?.let { ", olderThan=${java.time.Instant.ofEpochMilli(it)}" } ?: ""})...")
+        logger("  $type: querying (newest first, limit=$limit${olderThan?.let { ", olderThan=${java.time.Instant.ofEpochMilli(it)}" } ?: ""})...")
 
-            val result = healthProvider.readDataDescending(type, olderThan, SyncDefaults.CHUNK_SIZE)
+        val result = healthProvider.readDataDescending(type, olderThan, limit)
 
-            if (result.data.isEmpty) {
-                logger("  $type: all data sent (newest first)")
-                stateMutex.withLock {
-                    updateInMemoryProgress(type, 0, isComplete = true, anchorTimestamp = null)
-                    persistStateToDisk()
-                }
-                return true
-            }
-
-            val reachedFloor = floor != null && result.minTimestamp != null && result.minTimestamp <= floor
-            val isLastChunk = result.data.totalCount < SyncDefaults.CHUNK_SIZE || reachedFloor
-
-            val data = if (reachedFloor && floorIso != null) result.data.filterSince(floorIso) else result.data
-
-            if (data.isEmpty) {
-                logger("  $type: all data within range sent")
-                stateMutex.withLock {
-                    updateInMemoryProgress(type, 0, isComplete = true, anchorTimestamp = null)
-                    persistStateToDisk()
-                }
-                return true
-            }
-
-            val count = data.totalCount
-            val payload = buildPayload(data)
-            logPayloadSummary(data)
-            val sendResult = sendPayload(endpoint, payload)
-
-            if (!sendResult.success) {
-                val reason = sendResult.statusCode?.let { "HTTP $it" } ?: "network error"
-                logger("  $type: $count items -> failed ($reason)")
-                return false
-            }
-
-            val anchorTs = if (olderThan == null) result.maxTimestamp else null
-
-            logger("  $type: $count items sent (${sendResult.payloadSizeKb} KB) -> ${sendResult.statusCode}${if (reachedFloor) " [reached sync boundary]" else ""}")
-
-            stateMutex.withLock {
-                updateInMemoryProgress(type, count, isComplete = isLastChunk, anchorTimestamp = anchorTs)
-                if (isLastChunk) persistStateToDisk()
-            }
-
-            if (isLastChunk) return true
-
-            olderThan = result.minTimestamp
+        if (result.data.isEmpty) {
+            logger("  $type: all data sent (newest first)")
+            return FetchResult(type = type, isDone = true)
         }
+
+        val reachedFloor = floor != null && result.minTimestamp != null && result.minTimestamp <= floor
+        val isLastChunk = result.data.totalCount < limit || reachedFloor
+
+        val data = if (reachedFloor && floorIso != null) result.data.filterSince(floorIso) else result.data
+
+        if (data.isEmpty) {
+            logger("  $type: all data within range sent")
+            return FetchResult(type = type, isDone = true)
+        }
+
+        val anchorTs = if (olderThan == null) result.maxTimestamp else null
+        val nextOlderThan = if (isLastChunk) null else result.minTimestamp
+
+        logger("  $type: ${data.totalCount} samples (newest first)")
+
+        return FetchResult(
+            type = type, data = data, count = data.totalCount,
+            nextCursor = nextOlderThan, anchorTimestamp = anchorTs, isDone = isLastChunk
+        )
+    }
+
+    private suspend fun fetchOneChunkIncremental(
+        type: String,
+        anchor: Long?,
+        limit: Int
+    ): FetchResult {
+        logger("  $type: querying (limit=$limit)...")
+
+        val result = healthProvider.readData(type, anchor, limit)
+
+        if (result.data.isEmpty) {
+            logger("  $type: no new data")
+            return FetchResult(type = type, isDone = true)
+        }
+
+        val count = result.data.totalCount
+        val isLastChunk = count < limit
+
+        logger("  $type: $count samples")
+
+        return FetchResult(
+            type = type, data = result.data, count = count,
+            nextCursor = result.maxTimestamp, anchorTimestamp = result.maxTimestamp,
+            isDone = isLastChunk
+        )
     }
 
     private fun updateInMemoryProgress(typeIdentifier: String, sentInChunk: Int, isComplete: Boolean, anchorTimestamp: Long?) {
@@ -465,11 +494,10 @@ class SyncManager(
             val refreshToken = secureStorage.getRefreshToken()
             val apiBaseUrl = secureStorage.apiBaseUrl
             if (refreshToken == null || apiBaseUrl == null) {
-                android.util.Log.w(TAG, "No refresh token or host - cannot refresh")
+                logger("Token refresh: missing credentials")
                 return@withContext false
             }
 
-            android.util.Log.d(TAG, "Attempting token refresh...")
             val url = "$apiBaseUrl/token/refresh"
             val bodyMap = mapOf("refresh_token" to refreshToken)
             val body = json.encodeToString(bodyMap)
@@ -481,23 +509,24 @@ class SyncManager(
 
             val response = httpClient.newCall(request).execute()
             val responseBody = response.body?.string()
-            android.util.Log.d(TAG, "Token refresh response [${response.code}]")
 
             if (response.isSuccessful && responseBody != null) {
                 val jsonObj = json.parseToJsonElement(responseBody).jsonObject
                 val newAccessToken = jsonObj["access_token"]?.jsonPrimitive?.contentOrNull
+                val newRefreshToken = jsonObj["refresh_token"]?.jsonPrimitive?.contentOrNull
                 if (newAccessToken != null) {
-                    val newRefreshToken = jsonObj["refresh_token"]?.jsonPrimitive?.contentOrNull
                     secureStorage.updateTokens(newAccessToken, newRefreshToken)
-                    logger("Token refreshed")
+                    logger("Token refresh: HTTP ${response.code}")
                     return@withContext true
+                } else {
+                    logger("Token refresh failed: HTTP ${response.code} (no access_token in response)")
                 }
+            } else {
+                logger("Token refresh failed: HTTP ${response.code}")
             }
-            logger("Token refresh failed (HTTP ${response.code})")
             false
         } catch (e: Exception) {
-            android.util.Log.e(TAG, "Token refresh error", e)
-            logger("Token refresh failed")
+            logger("Token refresh failed: ${e.javaClass.simpleName}: ${e.message}")
             false
         } finally {
             tokenRefreshLock.withLock { isRefreshingToken = false }
@@ -509,58 +538,85 @@ class SyncManager(
     private data class SendResult(val success: Boolean, val statusCode: Int?, val payloadSizeKb: Int)
 
     private suspend fun sendPayload(endpoint: String, payload: Map<String, Any>): SendResult {
-        val jsonBody = serializePayload(payload)
-        return sendPayloadRaw(endpoint, jsonBody)
+        val body = streamingJsonBody(payload)
+        return sendWithBody(endpoint, body)
     }
 
-    private fun serializePayload(payload: Map<String, Any>): String {
-        val element = mapToJsonElement(payload)
-        return json.encodeToString(JsonElement.serializer(), element)
-    }
-
-    private fun mapToJsonElement(value: Any?): JsonElement {
-        return when (value) {
-            null -> JsonNull
-            is Boolean -> JsonPrimitive(value)
-            is Number -> JsonPrimitive(value)
-            is String -> JsonPrimitive(value)
-            is Map<*, *> -> JsonObject(
-                value.entries.associate { (k, v) -> k.toString() to mapToJsonElement(v) }
-            )
-            is List<*> -> JsonArray(value.map { mapToJsonElement(it) })
-            else -> JsonPrimitive(value.toString())
+    /**
+     * Creates an OkHttp RequestBody that streams JSON directly from the Map
+     * to the network via android.util.JsonWriter. No intermediate JsonElement
+     * tree or full String is allocated — only the writer's small internal buffer
+     * is held in heap, making memory usage O(depth) instead of O(n).
+     */
+    private fun streamingJsonBody(payload: Map<String, Any>): RequestBody {
+        return object : okhttp3.RequestBody() {
+            override fun contentType() = "application/json".toMediaType()
+            override fun writeTo(sink: okio.BufferedSink) {
+                val writer = android.util.JsonWriter(
+                    java.io.OutputStreamWriter(sink.outputStream(), Charsets.UTF_8)
+                )
+                writeValue(writer, payload)
+                writer.flush()
+            }
         }
     }
 
-    private suspend fun sendPayloadRaw(endpoint: String, jsonBody: String): SendResult =
+    private fun writeValue(writer: android.util.JsonWriter, value: Any?) {
+        when (value) {
+            null -> writer.nullValue()
+            is Boolean -> writer.value(value)
+            is Int -> writer.value(value.toLong())
+            is Long -> writer.value(value)
+            is Float -> writer.value(value.toDouble())
+            is Double -> writer.value(value)
+            is Number -> writer.value(value.toDouble())
+            is String -> writer.value(value)
+            is Map<*, *> -> {
+                writer.beginObject()
+                for ((k, v) in value) {
+                    writer.name(k.toString())
+                    writeValue(writer, v)
+                }
+                writer.endObject()
+            }
+            is List<*> -> {
+                writer.beginArray()
+                for (item in value) {
+                    writeValue(writer, item)
+                }
+                writer.endArray()
+            }
+            else -> writer.value(value.toString())
+        }
+    }
+
+    private suspend fun sendWithBody(endpoint: String, body: okhttp3.RequestBody): SendResult =
         withContext(dispatchers.io) {
             try {
-                val sizeKb = jsonBody.length / 1024
-                android.util.Log.d(TAG, "REQUEST [$endpoint] (${sizeKb} KB)")
-
                 val requestBuilder = Request.Builder()
                     .url(endpoint)
-                    .post(jsonBody.toRequestBody("application/json".toMediaType()))
+                    .post(body)
                     .header("Content-Type", "application/json")
                 applyAuth(requestBuilder)
 
                 val response = httpClient.newCall(requestBuilder.build()).execute()
-                android.util.Log.d(TAG, "RESPONSE [${response.code}]")
+                val sizeKb = (response.header("Content-Length")?.toLongOrNull() ?: 0L) / 1024
 
-                if (response.isSuccessful) return@withContext SendResult(true, response.code, sizeKb)
+                if (response.isSuccessful) return@withContext SendResult(true, response.code, sizeKb.toInt())
                 if (response.code == 401) {
-                    val retryOk = handle401(endpoint, jsonBody)
-                    return@withContext SendResult(retryOk, if (retryOk) 200 else 401, sizeKb)
+                    logger("Got 401, refreshing token...")
+                    val retryOk = handle401(endpoint, body)
+                    return@withContext SendResult(retryOk, if (retryOk) 200 else 401, sizeKb.toInt())
                 }
 
-                SendResult(false, response.code, sizeKb)
+                SendResult(false, response.code, sizeKb.toInt())
             } catch (e: Exception) {
-                android.util.Log.e(TAG, "Upload error", e)
+                logger("Upload error: ${e.javaClass.simpleName}: ${e.message}")
                 SendResult(false, null, 0)
             }
         }
 
-    private suspend fun handle401(endpoint: String, jsonBody: String): Boolean {
+    private suspend fun handle401(endpoint: String, body: okhttp3.RequestBody): Boolean {
         if (secureStorage.isApiKeyAuth) {
             emitAuthError(401)
             return false
@@ -569,21 +625,24 @@ class SyncManager(
         if (attemptTokenRefresh()) {
             val newCredential = secureStorage.authCredential
             if (newCredential != null) {
-                android.util.Log.d(TAG, "Retrying upload with refreshed token...")
+                logger("Token refreshed, retrying...")
                 return try {
                     val retryBuilder = Request.Builder()
                         .url(endpoint)
-                        .post(jsonBody.toRequestBody("application/json".toMediaType()))
+                        .post(body)
                         .header("Content-Type", "application/json")
                     applyAuth(retryBuilder, newCredential)
 
                     val retryResponse = httpClient.newCall(retryBuilder.build()).execute()
-                    android.util.Log.d(TAG, "Retry RESPONSE [${retryResponse.code}]")
-
-                    if (retryResponse.isSuccessful) true
-                    else { emitAuthError(401); false }
+                    if (retryResponse.isSuccessful) {
+                        logger("Retry: HTTP ${retryResponse.code}")
+                        true
+                    } else {
+                        logger("Retry failed: HTTP ${retryResponse.code}")
+                        emitAuthError(401); false
+                    }
                 } catch (e: Exception) {
-                    android.util.Log.e(TAG, "Retry failed", e)
+                    logger("Retry failed: ${e.message}")
                     emitAuthError(401); false
                 }
             }
@@ -621,10 +680,9 @@ class SyncManager(
     private fun saveAnchor(type: String, timestamp: Long) {
         val current = loadAnchors().toMutableMap()
         current[type] = timestamp
-        val element = mapToJsonElement(current)
         syncPrefs.edit().putString(
             StorageKeys.KEY_ANCHORS,
-            json.encodeToString(JsonElement.serializer(), element)
+            json.encodeToString(current.mapValues { it.value.toDouble() })
         ).apply()
     }
 


### PR DESCRIPTION
## Summary
- Replaced in-memory JsonElement tree with `android.util.JsonWriter` streaming to fix OutOfMemoryError on 90+ day syncs with dense data
- All health types merged into a single payload per sync round (was one request per type)
- Normalized Bearer prefix on tokens from refresh endpoint
- Fixed EncryptedSharedPreferences.clear() bug on signOut — now removes keys individually with .commit()
- Added `setSyncNotification(title, text)` to customize the foreground service notification
- Removed Samsung SDK reflection spam, per-record conversion logs, and all token values from log output
