### PR TITLE
fix: change foreground service type from dataSync to health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.8.0
+
+* **Breaking: Foreground service type changed from `dataSync` to `health`**. Apps must update their Play Console FGS declaration from "Data Sync" to "Health" and remove any manual `<service>` declaration with `foregroundServiceType="dataSync"` from their manifest.
+* Replaced `FOREGROUND_SERVICE_DATA_SYNC` permission with `FOREGROUND_SERVICE_HEALTH`.
+* Added `HIGH_SAMPLING_RATE_SENSORS` permission to satisfy the `health` FGS runtime prerequisite.
+* Updated `HealthSyncWorker.getForegroundInfo()` to pass `FOREGROUND_SERVICE_TYPE_HEALTH`.
+
 ## 0.7.0
 
 * **Combined payloads**: all health data types are now merged into a single payload per sync round instead of separate requests per type.

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -80,7 +80,7 @@ afterEvaluate {
                 from(components["release"])
                 groupId = "com.openwearables.health"
                 artifactId = "sdk"
-                version = "0.7.0"
+                version = "0.8.0"
 
                 pom {
                     name.set("Open Wearables Health SDK")

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
 
     <!-- Required for background sync -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_HEALTH" />
+    <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -47,10 +48,9 @@
     </queries>
 
     <application>
-        <!-- WorkManager foreground service needs dataSync type for background health reads -->
         <service
             android:name="androidx.work.impl.foreground.SystemForegroundService"
-            android:foregroundServiceType="dataSync"
+            android:foregroundServiceType="health"
             tools:node="merge" />
     </application>
 

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/Constants.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/Constants.kt
@@ -16,7 +16,7 @@ object SyncDefaults {
     const val CHUNK_SIZE = 2000
     const val WORK_NAME_PERIODIC = "health_sync_periodic"
     const val WORK_NAME_EXPEDITED = "health_sync_expedited"
-    const val SDK_VERSION = "0.7.0"
+    const val SDK_VERSION = "0.8.0"
 }
 
 object StorageKeys {

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/HealthSyncWorker.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/HealthSyncWorker.kt
@@ -75,7 +75,7 @@ class HealthSyncWorker(
             .setOngoing(true)
             .build()
         return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
-            ForegroundInfo(NotificationConfig.NOTIFICATION_ID, notification, android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+            ForegroundInfo(NotificationConfig.NOTIFICATION_ID, notification, android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_HEALTH)
         } else {
             ForegroundInfo(NotificationConfig.NOTIFICATION_ID, notification)
         }


### PR DESCRIPTION
## Summary
- Changed `foregroundServiceType` from `dataSync` to `health` across the native Android SDK
  manifest, Flutter plugin manifest, and `HealthSyncWorker.getForegroundInfo()`
- Replaced `FOREGROUND_SERVICE_DATA_SYNC` permission with `FOREGROUND_SERVICE_HEALTH`
- Added `HIGH_SAMPLING_RATE_SENSORS` as a normal (auto-granted) permission to satisfy the
  `health` FGS runtime prerequisite without requiring additional user prompts
- Removed the manual service declaration from the example app — the SDK now provides it
  via manifest merge
