### PR TITLE
fix: smarter token refresh error handling, bump to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.0
+
+* **Smarter token refresh error handling**: token refresh failures are now classified as either `AUTH_FAILURE` (refresh token rejected with 401/403) or `NETWORK_ERROR` (timeout, DNS, 5xx). Only genuine auth failures trigger user disconnect — transient network errors during refresh no longer force sign-out, allowing the SDK's retry mechanism to recover automatically.
+
 ## 0.8.0
 
 * **Breaking: Foreground service type changed from `dataSync` to `health`**. Apps must update their Play Console FGS declaration from "Data Sync" to "Health" and remove any manual `<service>` declaration with `foregroundServiceType="dataSync"` from their manifest.

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -80,7 +80,7 @@ afterEvaluate {
                 from(components["release"])
                 groupId = "com.openwearables.health"
                 artifactId = "sdk"
-                version = "0.8.0"
+                version = "0.9.0"
 
                 pom {
                     name.set("Open Wearables Health SDK")

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/Constants.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/Constants.kt
@@ -16,7 +16,7 @@ object SyncDefaults {
     const val CHUNK_SIZE = 2000
     const val WORK_NAME_PERIODIC = "health_sync_periodic"
     const val WORK_NAME_EXPEDITED = "health_sync_expedited"
-    const val SDK_VERSION = "0.8.0"
+    const val SDK_VERSION = "0.9.0"
 }
 
 object StorageKeys {

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/SyncManager.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/SyncManager.kt
@@ -488,14 +488,18 @@ class SyncManager(
 
     // MARK: - Token Refresh
 
-    private suspend fun attemptTokenRefresh(): Boolean = withContext(dispatchers.io) {
+    private enum class TokenRefreshResult {
+        SUCCESS, AUTH_FAILURE, NETWORK_ERROR
+    }
+
+    private suspend fun attemptTokenRefresh(): TokenRefreshResult = withContext(dispatchers.io) {
         tokenRefreshLock.withLock { isRefreshingToken = true }
         try {
             val refreshToken = secureStorage.getRefreshToken()
             val apiBaseUrl = secureStorage.apiBaseUrl
             if (refreshToken == null || apiBaseUrl == null) {
                 logger("Token refresh: missing credentials")
-                return@withContext false
+                return@withContext TokenRefreshResult.AUTH_FAILURE
             }
 
             val url = "$apiBaseUrl/token/refresh"
@@ -510,6 +514,11 @@ class SyncManager(
             val response = httpClient.newCall(request).execute()
             val responseBody = response.body?.string()
 
+            if (response.code in 401..403) {
+                logger("Token refresh rejected: HTTP ${response.code}")
+                return@withContext TokenRefreshResult.AUTH_FAILURE
+            }
+
             if (response.isSuccessful && responseBody != null) {
                 val jsonObj = json.parseToJsonElement(responseBody).jsonObject
                 val newAccessToken = jsonObj["access_token"]?.jsonPrimitive?.contentOrNull
@@ -517,17 +526,17 @@ class SyncManager(
                 if (newAccessToken != null) {
                     secureStorage.updateTokens(newAccessToken, newRefreshToken)
                     logger("Token refresh: HTTP ${response.code}")
-                    return@withContext true
+                    return@withContext TokenRefreshResult.SUCCESS
                 } else {
                     logger("Token refresh failed: HTTP ${response.code} (no access_token in response)")
                 }
             } else {
                 logger("Token refresh failed: HTTP ${response.code}")
             }
-            false
+            TokenRefreshResult.NETWORK_ERROR
         } catch (e: Exception) {
             logger("Token refresh failed: ${e.javaClass.simpleName}: ${e.message}")
-            false
+            TokenRefreshResult.NETWORK_ERROR
         } finally {
             tokenRefreshLock.withLock { isRefreshingToken = false }
         }
@@ -622,33 +631,43 @@ class SyncManager(
             return false
         }
 
-        if (attemptTokenRefresh()) {
-            val newCredential = secureStorage.authCredential
-            if (newCredential != null) {
-                logger("Token refreshed, retrying...")
-                return try {
-                    val retryBuilder = Request.Builder()
-                        .url(endpoint)
-                        .post(body)
-                        .header("Content-Type", "application/json")
-                    applyAuth(retryBuilder, newCredential)
+        when (attemptTokenRefresh()) {
+            TokenRefreshResult.SUCCESS -> {
+                val newCredential = secureStorage.authCredential
+                if (newCredential != null) {
+                    logger("Token refreshed, retrying...")
+                    return try {
+                        val retryBuilder = Request.Builder()
+                            .url(endpoint)
+                            .post(body)
+                            .header("Content-Type", "application/json")
+                        applyAuth(retryBuilder, newCredential)
 
-                    val retryResponse = httpClient.newCall(retryBuilder.build()).execute()
-                    if (retryResponse.isSuccessful) {
-                        logger("Retry: HTTP ${retryResponse.code}")
-                        true
-                    } else {
-                        logger("Retry failed: HTTP ${retryResponse.code}")
-                        emitAuthError(401); false
+                        val retryResponse = httpClient.newCall(retryBuilder.build()).execute()
+                        if (retryResponse.isSuccessful) {
+                            logger("Retry: HTTP ${retryResponse.code}")
+                            true
+                        } else {
+                            logger("Retry failed: HTTP ${retryResponse.code}")
+                            if (retryResponse.code in 401..403) emitAuthError(401)
+                            false
+                        }
+                    } catch (e: Exception) {
+                        logger("Retry failed: ${e.message}")
+                        false
                     }
-                } catch (e: Exception) {
-                    logger("Retry failed: ${e.message}")
-                    emitAuthError(401); false
                 }
+                return false
+            }
+            TokenRefreshResult.AUTH_FAILURE -> {
+                emitAuthError(401)
+                return false
+            }
+            TokenRefreshResult.NETWORK_ERROR -> {
+                logger("Token refresh failed (network) - will retry later")
+                return false
             }
         }
-        emitAuthError(401)
-        return false
     }
 
     // MARK: - Sync Endpoint


### PR DESCRIPTION
### Summary
- Introduced `TokenRefreshResult` enum (`SUCCESS`, `AUTH_FAILURE`, `NETWORK_ERROR`) to classify token refresh outcomes
- Only genuine authentication failures (401/403 from the refresh endpoint) now trigger `emitAuthError` and user disconnect
- Transient network errors (timeout, DNS, 5xx) during token refresh are logged and allow the SDK's retry mechanism to recover automatically
- Updated `SyncManager.handle401` to use the new classification

### Problem
Users were being forcefully disconnected even when their tokens were still valid - any failure during token refresh (including transient network issues) was treated as an auth error, triggering sign-out.
