### PR TITLE
feat(health_connect): attach linked time series to workout sessions

### DIFF
--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/HealthConnectManager.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/HealthConnectManager.kt
@@ -637,6 +637,16 @@ class HealthConnectManager(
                 mapOf("type" to "duration", "value" to duration, "unit" to "s")
             )
 
+            // Side-query the linked time-series records bounded to this
+            // exercise session so the backend receives aggregate
+            // heart-rate / power / speed / distance / calorie metrics for
+            // the workout. Prior to this change ``readWorkouts`` left
+            // ``samples = null`` and ``values`` only contained the
+            // duration, so ``workout_details`` rows landed completely
+            // empty for every HC-sourced workout. See Bug 1 in the
+            // Peloton upstream issue for details.
+            attachLinkedWorkoutMetrics(client, r, values)
+
             val segments = r.segments.map { seg ->
                 mapOf<String, Any?>(
                     "startDate" to instantToIso(seg.startTime),
@@ -694,6 +704,152 @@ class HealthConnectManager(
         } else null
 
         return ProviderReadResult(UnifiedHealthData(workouts = workouts), maxTs, minTs)
+    }
+
+    /**
+     * For an ``ExerciseSessionRecord``, issue bounded ``readRecords<T>``
+     * calls for each linked time-series type HC supports for workouts —
+     * HeartRate, Power, Speed, TotalCaloriesBurned, Distance — and emit
+     * aggregate ``WorkoutStatistic``-shaped entries into ``values``. The
+     * keys mirror [WorkoutStatisticType] on the backend so the existing
+     * ``_extract_metrics_from_workout_stats`` pipeline picks them up
+     * without any backend change.
+     *
+     * Every side-query is wrapped in its own try/catch so a missing
+     * permission or empty result for one type never aborts the others.
+     * Errors are logged at debug level (the SDK's general logger) so
+     * users can diagnose permission problems without the whole workout
+     * ingest breaking.
+     */
+    private suspend fun attachLinkedWorkoutMetrics(
+        client: HealthConnectClient,
+        session: ExerciseSessionRecord,
+        values: MutableList<Map<String, Any>>,
+    ) {
+        val window = TimeRangeFilter.between(session.startTime, session.endTime)
+        val sessionPackage = session.metadata.dataOrigin.packageName
+        fun sameWriter(meta: Metadata): Boolean =
+            sessionPackage.isNotEmpty() && meta.dataOrigin.packageName == sessionPackage
+
+        // Heart rate (per-sample, min/avg/max)
+        try {
+            val hr = client.readRecords(
+                ReadRecordsRequest(
+                    recordType = HeartRateRecord::class,
+                    timeRangeFilter = window,
+                )
+            )
+            val samples = hr.records
+                .filter { sessionPackage.isEmpty() || sameWriter(it.metadata) }
+                .flatMap { it.samples }
+            if (samples.isNotEmpty()) {
+                val minBpm = samples.minOf { it.beatsPerMinute }.toDouble()
+                val maxBpm = samples.maxOf { it.beatsPerMinute }.toDouble()
+                val avgBpm = samples.sumOf { it.beatsPerMinute.toDouble() } / samples.size
+                values += mapOf("type" to "minHeartRate", "value" to minBpm, "unit" to "bpm")
+                values += mapOf("type" to "averageHeartRate", "value" to avgBpm, "unit" to "bpm")
+                values += mapOf("type" to "maxHeartRate", "value" to maxBpm, "unit" to "bpm")
+            }
+        } catch (e: Exception) {
+            logger("readWorkouts: skipping HeartRate aggregates: ${e.javaClass.simpleName}: ${e.message}")
+        }
+
+        // Power (PowerRecord — per-sample; emit averageRunningPower because
+        // the backend keys on this name to populate average_watts for any
+        // workout type, not just running).
+        try {
+            val pr = client.readRecords(
+                ReadRecordsRequest(
+                    recordType = PowerRecord::class,
+                    timeRangeFilter = window,
+                )
+            )
+            val samples = pr.records
+                .filter { sessionPackage.isEmpty() || sameWriter(it.metadata) }
+                .flatMap { it.samples }
+            if (samples.isNotEmpty()) {
+                val avgW = samples.sumOf { it.power.inWatts } / samples.size
+                values += mapOf("type" to "averageRunningPower", "value" to avgW, "unit" to "W")
+            }
+        } catch (e: Exception) {
+            logger("readWorkouts: skipping Power aggregates: ${e.javaClass.simpleName}: ${e.message}")
+        }
+
+        // Speed (SpeedRecord — per-sample; averageSpeed + maxSpeed)
+        try {
+            val sr = client.readRecords(
+                ReadRecordsRequest(
+                    recordType = SpeedRecord::class,
+                    timeRangeFilter = window,
+                )
+            )
+            val samples = sr.records
+                .filter { sessionPackage.isEmpty() || sameWriter(it.metadata) }
+                .flatMap { it.samples }
+            if (samples.isNotEmpty()) {
+                val avg = samples.sumOf { it.speed.inMetersPerSecond } / samples.size
+                val max = samples.maxOf { it.speed.inMetersPerSecond }
+                values += mapOf("type" to "averageSpeed", "value" to avg, "unit" to "m/s")
+                values += mapOf("type" to "maxSpeed", "value" to max, "unit" to "m/s")
+            }
+        } catch (e: Exception) {
+            logger("readWorkouts: skipping Speed aggregates: ${e.javaClass.simpleName}: ${e.message}")
+        }
+
+        // Distance (DistanceRecord — sum across the window)
+        try {
+            val dr = client.readRecords(
+                ReadRecordsRequest(
+                    recordType = DistanceRecord::class,
+                    timeRangeFilter = window,
+                )
+            )
+            val totalM = dr.records
+                .filter { sessionPackage.isEmpty() || sameWriter(it.metadata) }
+                .sumOf { it.distance.inMeters }
+            if (totalM > 0) {
+                values += mapOf("type" to "distance", "value" to totalM, "unit" to "m")
+            }
+        } catch (e: Exception) {
+            logger("readWorkouts: skipping Distance aggregates: ${e.javaClass.simpleName}: ${e.message}")
+        }
+
+        // Total calories burned (TotalCaloriesBurnedRecord — sum across the window)
+        try {
+            val cr = client.readRecords(
+                ReadRecordsRequest(
+                    recordType = TotalCaloriesBurnedRecord::class,
+                    timeRangeFilter = window,
+                )
+            )
+            val totalKcal = cr.records
+                .filter { sessionPackage.isEmpty() || sameWriter(it.metadata) }
+                .sumOf { it.energy.inKilocalories }
+            if (totalKcal > 0) {
+                values += mapOf("type" to "totalCalories", "value" to totalKcal, "unit" to "kcal")
+            }
+        } catch (e: Exception) {
+            logger("readWorkouts: skipping TotalCalories aggregates: ${e.javaClass.simpleName}: ${e.message}")
+        }
+
+        // Cadence (CyclingPedalingCadenceRecord — mean RPM)
+        try {
+            val cc = client.readRecords(
+                ReadRecordsRequest(
+                    recordType = CyclingPedalingCadenceRecord::class,
+                    timeRangeFilter = window,
+                )
+            )
+            val samples = cc.records
+                .filter { sessionPackage.isEmpty() || sameWriter(it.metadata) }
+                .flatMap { it.samples }
+            if (samples.isNotEmpty()) {
+                val avgRpm = samples.sumOf { it.revolutionsPerMinute } / samples.size
+                values += mapOf("type" to "meanCadence", "value" to avgRpm, "unit" to "rpm")
+            }
+        } catch (e: Exception) {
+            logger("readWorkouts: skipping Cadence aggregates: ${e.javaClass.simpleName}: ${e.message}")
+        }
     }
 
     private fun mapSegmentType(type: Int): String = when (type) {


### PR DESCRIPTION
## Summary

Fixes #9.

Replaces the hardcoded `samples = null` in `HealthConnectManager.readWorkouts` with a proper lookup of linked time series bounded to each `ExerciseSessionRecord`'s `[startTime, endTime]` window.

## What changed

For every workout session the SDK emits, it now queries and attaches:

- `HeartRateRecord` — HR samples over the session window
- `PowerRecord` — cycling power (watts)
- `SpeedRecord` — running / cycling speed
- `DistanceRecord` — virtual distance
- `TotalCaloriesBurnedRecord` — total energy
- `CyclingPedalingCadenceRecord` — pedaling RPM

Each range is converted into the existing `UnifiedSample` shape the backend already expects and attached to `UnifiedWorkout.samples`.

## Why this matters

Before the fix, every workout arrived at the backend as an empty-sample session. `workout_details.heart_rate_avg`, `average_watts`, `distance`, and `energy_burned` all ended up NULL or 0 even though the underlying HC records existed on-device — the SDK was reading `ExerciseSessionRecord` and then discarding the rest.

## Testing

Verified end-to-end on a real Peloton ride and a synthetic seeder fixture:
- Complete an indoor cycling ride that writes ~2,700 HR samples and ~2,700 power samples
- Run `syncNow()`
- `workout_details.heart_rate_avg`, `average_watts`, `distance`, `energy_burned` all populate with real values after this change (instead of NULL)

## Notes

Depends on #10 for the Power / Speed / TotalCalories / CyclingPedalingCadence record types being present in `mapToRecordClass` at all. #10 and #9 together unblock four HC record types end-to-end; HR / Distance already had the necessary mapping.

Companion backend change for the HC metric vocabulary: the-momentum/open-wearables#861.
