### PR TITLE
fix(health_connect): descending pagination cursor + countRecordsForTypes pageSize cap

### DIFF
--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/HealthConnectManager.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/HealthConnectManager.kt
@@ -275,10 +275,44 @@ class HealthConnectManager(
         val result = convert(response.records)
 
         val minTs = if (!ascending && response.records.isNotEmpty()) {
-            getRecordTimestamp(response.records.last())
+            // Use startTime (minus 1ms) rather than endTime so the next
+            // descending page's `before(cursor)` strictly excludes this
+            // record. HC's before() filter tests against startTime, so a
+            // SeriesRecord like PowerRecord with [start, end] gets re-included
+            // when cursor = end and start < end.
+            getRecordStartMillis(response.records.last())?.minus(1)
         } else null
 
         return ProviderReadResult(result.data, result.maxTimestamp, minTs)
+    }
+
+    private fun getRecordStartMillis(record: Record): Long? = when (record) {
+        is StepsRecord -> record.startTime.toEpochMilli()
+        is HeartRateRecord -> record.startTime.toEpochMilli()
+        is RestingHeartRateRecord -> record.time.toEpochMilli()
+        is HeartRateVariabilityRmssdRecord -> record.time.toEpochMilli()
+        is OxygenSaturationRecord -> record.time.toEpochMilli()
+        is BloodPressureRecord -> record.time.toEpochMilli()
+        is BloodGlucoseRecord -> record.time.toEpochMilli()
+        is ActiveCaloriesBurnedRecord -> record.startTime.toEpochMilli()
+        is BasalMetabolicRateRecord -> record.time.toEpochMilli()
+        is BodyTemperatureRecord -> record.time.toEpochMilli()
+        is WeightRecord -> record.time.toEpochMilli()
+        is HeightRecord -> record.time.toEpochMilli()
+        is BodyFatRecord -> record.time.toEpochMilli()
+        is LeanBodyMassRecord -> record.time.toEpochMilli()
+        is FloorsClimbedRecord -> record.startTime.toEpochMilli()
+        is DistanceRecord -> record.startTime.toEpochMilli()
+        is HydrationRecord -> record.startTime.toEpochMilli()
+        is Vo2MaxRecord -> record.time.toEpochMilli()
+        is RespiratoryRateRecord -> record.time.toEpochMilli()
+        is PowerRecord -> record.startTime.toEpochMilli()
+        is SpeedRecord -> record.startTime.toEpochMilli()
+        is TotalCaloriesBurnedRecord -> record.startTime.toEpochMilli()
+        is CyclingPedalingCadenceRecord -> record.startTime.toEpochMilli()
+        is ExerciseSessionRecord -> record.startTime.toEpochMilli()
+        is SleepSessionRecord -> record.startTime.toEpochMilli()
+        else -> null
     }
 
     private fun getRecordTimestamp(record: Record): Long? = when (record) {

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/SyncManager.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/SyncManager.kt
@@ -832,14 +832,15 @@ class SyncManager(
 
     private suspend fun countRecordsForTypes(types: List<String>, sinceTimestamp: Long?): Map<String, Int> {
         val counts = mutableMapOf<String, Int>()
+        val pageSize = 5000  // Health Connect caps readRecords pageSize at 5000.
         for (type in types) {
             try {
                 var count = 0
                 var cursor = sinceTimestamp
                 while (true) {
-                    val result = healthProvider.readData(type, cursor, 10000)
+                    val result = healthProvider.readData(type, cursor, pageSize)
                     count += result.data.totalCount
-                    if (result.data.totalCount < 10000 || result.maxTimestamp == null) break
+                    if (result.data.totalCount < pageSize || result.maxTimestamp == null) break
                     cursor = result.maxTimestamp
                 }
                 counts[type] = count


### PR DESCRIPTION
## Summary

Fixes #11.

Two small correctness fixes in the Health Connect read path, bundled because they're in the same file and both relate to HC paging.

### 1. Descending pagination re-includes boundary SeriesRecords

`HealthConnectManager.readData(...)` (descending mode) used the last record's `endTime` as the `before(cursor)` boundary for the next page. HC's `before()` filter tests `startTime`, not `endTime`. For instantaneous records (`HeartRate`, `HRV`, `Weight`, …) the two are equal so the filter worked. But for `SeriesRecord` types like `PowerRecord`, `SpeedRecord`, `DistanceRecord`, `ExerciseSessionRecord`, `SleepSessionRecord`, `startTime < endTime`, so the last record of page N reappeared as the first record of page N+1.

**Fix**: use a new helper `getRecordStartMillis(...)` that returns `startTime` for range-typed records and `time` for instant-typed records, then subtract 1ms to make `before()` strictly exclusive.

### 2. countRecordsForTypes pageSize=10000 exceeds HC's 5000 cap

`SyncManager.countRecordsForTypes` requested pages of 10,000 from `HealthConnectClient.readRecords`, but HC documents a cap of 5,000 per request. Depending on the HC version, HC either silently clamps the return to 5,000 or rejects the request outright. When it clamps, the loop's termination condition (`totalCount < 10000`) never fires correctly and the count silently under-reports.

**Fix**: define a named `pageSize = 5000` constant and use it for both the read call and the termination check.

## Testing

### Bug 1
- Write a long `PowerRecord` session via a seeder with `clientRecordId`s
- Call `readData("power", null, limit=10)` repeatedly in descending mode, following the returned cursor
- Before: the last record of page N reappeared on page N+1 (compare `clientRecordId`s)
- After: strictly excluded, no duplicates at any page boundary

### Bug 2
- Call `countRecordsForTypes(listOf("heartRate"), sinceTimestamp = null)` for an account with more than 5,000 HR records since epoch
- Before: returned count diverged from the actual Postgres row count
- After: matches the row count, loop terminates correctly

## Notes

Discovered while chasing down SeriesRecord data loss during a Peloton ride investigation (separate from the more visible "workout samples are null" defect in #9).
