### PR TITLE
Release v0.11.0: add setLogLevel + fix Maven version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.11.0
+
+* **Public `setLogLevel(level)` method** added for parity with iOS. Convenience wrapper around the existing `logLevel` property, intended for cross-platform bridges (React Native, Flutter) and Java callers. The `logLevel` property remains available.
+* **Fixed published Maven version**: the `:sdk` module publication was still declaring `0.9.0` in `build.gradle.kts` despite the `SDK_VERSION` constant being bumped. The published POM now matches the git tag and `SyncDefaults.SDK_VERSION`.
+
 ## 0.10.0
 
 * **Sync telemetry**: new `/logs` endpoint integration for initial full sync diagnostics.

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -80,7 +80,7 @@ afterEvaluate {
                 from(components["release"])
                 groupId = "com.openwearables.health"
                 artifactId = "sdk"
-                version = "0.9.0"
+                version = "0.11.0"
 
                 pom {
                     name.set("Open Wearables Health SDK")

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/Constants.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/Constants.kt
@@ -16,7 +16,7 @@ object SyncDefaults {
     const val CHUNK_SIZE = 2000
     const val WORK_NAME_PERIODIC = "health_sync_periodic"
     const val WORK_NAME_EXPEDITED = "health_sync_expedited"
-    const val SDK_VERSION = "0.10.0"
+    const val SDK_VERSION = "0.11.0"
 }
 
 object StorageKeys {

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/OpenWearablesHealthSDK.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/OpenWearablesHealthSDK.kt
@@ -449,6 +449,18 @@ class OpenWearablesHealthSDK private constructor(
         authErrorListener?.invoke(statusCode, message)
     }
 
+    // -----------------------------------------------------------------------
+    // Logging
+    // -----------------------------------------------------------------------
+
+    /**
+     * Sets the log level. Convenience wrapper mirroring the iOS API, intended
+     * for cross-platform bridges (React Native, Flutter) and Java callers.
+     */
+    fun setLogLevel(level: OWLogLevel) {
+        this.logLevel = level
+    }
+
     internal fun logMessage(message: String) {
         when (logLevel) {
             OWLogLevel.NONE -> return


### PR DESCRIPTION
## Summary

- Add public `setLogLevel(level: OWLogLevel)` on `OpenWearablesHealthSDK` for parity with iOS and a stable API for RN/Flutter/Java bridges. The existing `logLevel` property is preserved — no breaking change.
- Fix `:sdk` Maven publication: `build.gradle.kts` was hardcoded to `0.9.0` while the `v0.10.0` tag and `SDK_VERSION` were already bumped, so consumers pulled a POM out of sync with the tag. Bump to `0.11.0` so git tag, published POM and `SyncDefaults.SDK_VERSION` all match.
