### PR TITLE
Fix JVM signature clash caused by redundant logLevel setter

### DIFF
--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/OpenWearablesHealthSDK.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/OpenWearablesHealthSDK.kt
@@ -453,14 +453,6 @@ class OpenWearablesHealthSDK private constructor(
     // Logging
     // -----------------------------------------------------------------------
 
-    /**
-     * Sets the log level. Convenience wrapper mirroring the iOS API, intended
-     * for cross-platform bridges (React Native, Flutter) and Java callers.
-     */
-    fun setLogLevel(level: OWLogLevel) {
-        this.logLevel = level
-    }
-
     internal fun logMessage(message: String) {
         when (logLevel) {
             OWLogLevel.NONE -> return


### PR DESCRIPTION
Removes the redundant setLogLevel() method from OpenWearablesHealthSDK.

The logLevel property already exposes a generated setter, so the explicit setLogLevel() method results in a JVM signature clash during compilation.

This change preserves the existing API behavior while resolving the Android build/publishing error.