### PR TITLE
expose initialExportDone/isSyncing in getSyncStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 0.11.2
+
+* **New `getSyncStatus()` fields**: `initialExportDone` (Bool) and `isSyncing` (Bool) — allows apps to show progress UI during the initial historical export.
+
 ## 0.11.1
 
-* **Fixed JVM signature clash**: removed the redundant `setLogLevel` setter that clashed with the `logLevel` property's generated JVM signature. The public `setLogLevel(level)` method and the `logLevel` property both remain available.
+* **Fixed JVM signature clash**: removed the redundant `setLogLevel` setter that clashed with the `logLevel` property's generated JVM signature.
 
 ## 0.11.0
 

--- a/README.md
+++ b/README.md
@@ -236,9 +236,6 @@ sdk.authErrorListener = { statusCode, message ->
 ### Sync Control
 
 ```kotlin
-// Trigger sync immediately
-sdk.syncNow()
-
 // Check sync status
 val status = sdk.getSyncStatus()
 // {"hasResumableSession": true, "sentCount": 1500, "completedTypes": 3, ...}

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/OpenWearablesHealthSDK.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/OpenWearablesHealthSDK.kt
@@ -289,11 +289,6 @@ class OpenWearablesHealthSDK private constructor(
         logMessage("Background sync stopped")
     }
 
-    suspend fun syncNow() {
-        val h = host ?: throw IllegalStateException("Host not configured")
-        ensureSyncManager().syncNow(h, customSyncUrl, fullExport = false)
-    }
-
     fun resetAnchors() {
         val sm = ensureSyncManager()
         sm.resetAnchors()
@@ -453,13 +448,8 @@ class OpenWearablesHealthSDK private constructor(
     // Logging
     // -----------------------------------------------------------------------
 
-    /**
-     * Sets the log level. Convenience wrapper mirroring the iOS API, intended
-     * for cross-platform bridges (React Native, Flutter) and Java callers.
-     */
-    fun setLogLevel(level: OWLogLevel) {
-        this.logLevel = level
-    }
+    // Note: `var logLevel` already exposes a `setLogLevel(OWLogLevel)` accessor
+    // for Java callers; an explicit fun with that name would clash with it.
 
     internal fun logMessage(message: String) {
         when (logLevel) {

--- a/sdk/src/main/kotlin/com/openwearables/health/sdk/SyncManager.kt
+++ b/sdk/src/main/kotlin/com/openwearables/health/sdk/SyncManager.kt
@@ -1005,12 +1005,17 @@ class SyncManager(
 
     fun getSyncStatus(): Map<String, Any?> {
         val state = inMemoryState ?: loadSyncStateFromDisk()
+        // Whether the initial full export (whole history) has ever completed for
+        // this user. While false, apps can show a "keep the app open" hint.
+        val initialExportDone = hasCompletedInitialSync()
         return if (state != null) {
             mapOf(
                 "hasResumableSession" to state.hasProgress,
                 "sentCount" to state.totalSentCount,
                 "completedTypes" to state.completedTypes.size,
                 "isFullExport" to state.fullExport,
+                "initialExportDone" to initialExportDone,
+                "isSyncing" to isSyncing.get(),
                 "createdAt" to dateFormatter.format(java.time.Instant.ofEpochMilli(state.createdAt))
             )
         } else {
@@ -1019,6 +1024,8 @@ class SyncManager(
                 "sentCount" to 0,
                 "completedTypes" to 0,
                 "isFullExport" to false,
+                "initialExportDone" to initialExportDone,
+                "isSyncing" to isSyncing.get(),
                 "createdAt" to null
             )
         }


### PR DESCRIPTION
getSyncStatus() now returns initialExportDone (bool) and isSyncing (bool) — needed for the Flutter example app to show a "keep app open" banner during historical export.